### PR TITLE
US_1720_Update_initial_material 

### DIFF
--- a/UMI3D-SDK/Assets/ClientDevelopmentKit/Collaboration/Runtime/UMI3DLoadingParameters.cs
+++ b/UMI3D-SDK/Assets/ClientDevelopmentKit/Collaboration/Runtime/UMI3DLoadingParameters.cs
@@ -48,7 +48,7 @@ namespace umi3d.cdk
 
         public List<IResourcesLoader> ResourcesLoaders { get; } = new List<IResourcesLoader>() { new ObjMeshDtoLoader(), new ImageDtoLoader(), new GlTFMeshDtoLoader(), new BundleDtoLoader(), new AudioLoader() };
 
-        public List<AbstractUMI3DMaterialLoader> MaterialLoaders { get; } = new List<AbstractUMI3DMaterialLoader>() { new UMI3DExternalMaterialLoader(), new UMI3DPbrMaterialLoader() };
+        public List<AbstractUMI3DMaterialLoader> MaterialLoaders { get; } = new List<AbstractUMI3DMaterialLoader>() { new UMI3DExternalMaterialLoader(), new UMI3DPbrMaterialLoader(), new UMI3DOriginalMaterialLoader() };
 
         /// <summary>
         /// Load an UMI3DObject.

--- a/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/MaterialLoaders/AbstractUMI3DMaterialLoader.cs
+++ b/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/MaterialLoaders/AbstractUMI3DMaterialLoader.cs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 using MrtkShader;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using umi3d.common;
 using UnityEngine;
@@ -63,18 +64,18 @@ namespace umi3d.cdk
             }
         }
 
-   /*     public static void LoadTextureInMaterial(TextureDto textureDto, MRTKShaderUtils.ShaderProperty<Texture2D> materialKey, Material mat)
-        {
-            LoadTextureInMaterial(textureDto, (MRTKShaderUtils.ShaderProperty<Texture> )materialKey, mat);
-        }*/
+        /*     public static void LoadTextureInMaterial(TextureDto textureDto, MRTKShaderUtils.ShaderProperty<Texture2D> materialKey, Material mat)
+             {
+                 LoadTextureInMaterial(textureDto, (MRTKShaderUtils.ShaderProperty<Texture> )materialKey, mat);
+             }*/
 
-            /// <summary>
-            /// Load a texture from file or from cache and add it in the material
-            /// </summary>
-            /// <param name="textureDto">The texture dto with variants</param>
-            /// <param name="materialKey">The Shader property, it contains the id/name used to change the good texture in the material</param>
-            /// <param name="mat">the material to modify</param>
-            /// <param name="alternativeCallback">The basic callback is juste apply the new shader property in the shader but you can overide it to do some other action and then apply the property in the shader</param>
+        /// <summary>
+        /// Load a texture from file or from cache and add it in the material
+        /// </summary>
+        /// <param name="textureDto">The texture dto with variants</param>
+        /// <param name="materialKey">The Shader property, it contains the id/name used to change the good texture in the material</param>
+        /// <param name="mat">the material to modify</param>
+        /// <param name="alternativeCallback">The basic callback is juste apply the new shader property in the shader but you can overide it to do some other action and then apply the property in the shader</param>
         public static void LoadTextureInMaterial(TextureDto textureDto, MRTKShaderUtils.ShaderProperty<Texture2D> materialKey, Material mat, Action<Texture2D> alternativeCallback = null)
         {
             if (textureDto == null || textureDto.variants == null || textureDto.variants.Count < 1)
@@ -163,6 +164,7 @@ namespace umi3d.cdk
                     loader.DeleteObject
                     );
         }
+
 
         /// <summary>
         /// Set all properties of shaderAdditionalProperties in the material shader

--- a/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/MaterialLoaders/UMI3DOriginalMaterialLoader.cs
+++ b/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/MaterialLoaders/UMI3DOriginalMaterialLoader.cs
@@ -1,4 +1,17 @@
-﻿using System;
+/*
+Copyright 2019 Gfi Informatique
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using umi3d.common;

--- a/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/MaterialLoaders/UMI3DOriginalMaterialLoader.cs
+++ b/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/MaterialLoaders/UMI3DOriginalMaterialLoader.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using umi3d.common;
+using UnityEngine;
+
+namespace umi3d.cdk
+{
+    public class UMI3DOriginalMaterialLoader : AbstractUMI3DMaterialLoader
+    {
+        ///<inheritdoc/>        
+        public override bool IsSuitableFor(GlTFMaterialDto gltfMatDto)
+        {
+            if (gltfMatDto.extensions.umi3d is UMI3DOriginalMaterialDto)
+                return true;
+            return false;
+        }
+
+        ///<inheritdoc/>
+        public override void LoadMaterialFromExtension(GlTFMaterialDto dto, Action<Material> callback)
+        {
+            UMI3DOriginalMaterialDto originalMat = dto.extensions.umi3d as UMI3DOriginalMaterialDto;
+
+            if (originalMat != null)
+            {
+
+                callback.Invoke(null);
+
+
+
+            }
+            else
+            {
+                Debug.LogWarning("extension is null");
+            }
+        }
+
+
+    }
+}

--- a/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/MaterialLoaders/UMI3DOriginalMaterialLoader.cs.meta
+++ b/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/MaterialLoaders/UMI3DOriginalMaterialLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e9683188fdefd043888ff27877d7b50
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/UMI3DEnvironmentLoader.cs
+++ b/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/UMI3DEnvironmentLoader.cs
@@ -369,7 +369,7 @@ namespace umi3d.cdk
                     Parameters.SelectMaterialLoader(matDto).LoadMaterialFromExtension(matDto, (m) =>
                     {
 
-                        if (matDto.name != null && matDto.name.Length > 0)
+                        if (matDto.name != null && matDto.name.Length > 0 && m != null)
                             m.name = matDto.name;
                         //register the material
                         RegisterEntityInstance(((AbstractEntityDto)matDto.extensions.umi3d).id, matDto, m);

--- a/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/UMI3DNodeInstance.cs
+++ b/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/UMI3DNodeInstance.cs
@@ -52,7 +52,7 @@ namespace umi3d.cdk
         }
 
         /// <summary>
-        /// The list of Subnode intance when the model has tracked subMesh. Empty if sub Model are not tracked.
+        /// The list of Subnode instance when the model has tracked subMeshs. Empty if sub Models are not tracked.
         /// </summary>
         private List<UMI3DNodeInstance> _subNodeInstances;
         public List<UMI3DNodeInstance> subNodeInstances

--- a/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/UMI3DSceneLoader.cs
+++ b/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/UMI3DSceneLoader.cs
@@ -144,312 +144,171 @@ namespace umi3d.cdk
             return 1 - f;
         }
 
+        private bool SwitchOnMaterialProperties(UMI3DEntityInstance entity, SetEntityPropertyDto property, Material materialToModify)
+        {
+
+            switch (property.property)
+            {
+                case UMI3DPropertyKeys.RoughnessFactor:
+                    //        ((Material)entity.Object).SetFloat("_Roughness", (float)(double)property.value);
+                    //      ((Material)entity.Object).SetFloat("_Smoothness", RoughnessToSmoothness((float)(double)property.value)); 
+                    materialToModify.ApplyShaderProperty(MRTKShaderUtils.Smoothness, RoughnessToSmoothness((float)(double)property.value));
+
+                    ((GlTFMaterialDto)entity.dto).pbrMetallicRoughness.roughnessFactor = (float)(double)property.value;
+                    break;
+
+                case UMI3DPropertyKeys.MetallicFactor:
+                    materialToModify.ApplyShaderProperty(MRTKShaderUtils.Metallic, (float)(double)property.value);
+                    ((GlTFMaterialDto)entity.dto).pbrMetallicRoughness.metallicFactor = (float)(double)property.value;
+                    break;
+
+                case UMI3DPropertyKeys.BaseColorFactor:
+                    materialToModify.color = ((SerializableColor)property.value);
+                    ((GlTFMaterialDto)entity.dto).pbrMetallicRoughness.baseColorFactor = (SerializableColor)property.value;
+                    break;
+
+                case UMI3DPropertyKeys.EmissiveFactor:
+                    materialToModify.ApplyShaderProperty(MRTKShaderUtils.EmissiveColor, ((SerializableColor)property.value));
+                    ((GlTFMaterialDto)entity.dto).emissiveFactor = (Vector3)(Vector4)(Color)(SerializableColor)property.value;
+                    break;
+
+                case UMI3DPropertyKeys.Maintexture:
+                    AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.MainTex, materialToModify);
+                    ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).baseColorTexture = (TextureDto)property.value;
+                    break;
+
+                case UMI3DPropertyKeys.NormalTexture:
+                    AbstractUMI3DMaterialLoader.LoadTextureInMaterial((ScalableTextureDto)property.value, MRTKShaderUtils.NormalMap, materialToModify);
+                    ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).normalTexture = (ScalableTextureDto)property.value;
+                    break;
+
+                case UMI3DPropertyKeys.EmissiveTexture:
+                    AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.EmissionMap, materialToModify);
+                    ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).emissiveTexture = (TextureDto)property.value;
+                    break;
+
+                case UMI3DPropertyKeys.RoughnessTexture:
+                    AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.RoughnessMap, materialToModify);
+                    ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).roughnessTexture = (TextureDto)property.value;
+                    break;
+
+                case UMI3DPropertyKeys.MetallicTexture:
+                    AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.MetallicMap, materialToModify);
+                    ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).metallicTexture = (TextureDto)property.value;
+                    break;
+
+                case UMI3DPropertyKeys.ChannelTexture:
+                    AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.ChannelMap, materialToModify);
+                    ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).channelTexture = (TextureDto)property.value;
+                    break;
+
+                case UMI3DPropertyKeys.MetallicRoughnessTexture:
+                    AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.MetallicMap, materialToModify);
+                    AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.RoughnessMap, materialToModify);
+                    ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).metallicRoughnessTexture = (TextureDto)property.value;
+
+                    break;
+
+                case UMI3DPropertyKeys.OcclusionTexture:
+                    AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.OcclusionMap, materialToModify);
+                    ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).occlusionTexture = (TextureDto)property.value;
+                    break;
+
+                case UMI3DPropertyKeys.HeightTexture:
+                    Debug.LogWarning("Height Texture not supported");
+                    break;
+
+                case UMI3DPropertyKeys.TextureTilingOffset:
+                    Vector2 offset = (SerializableVector2)property.value;
+                    foreach (string textureName in materialToModify.GetTexturePropertyNames())
+                    {
+                        materialToModify.SetTextureOffset(textureName, offset);
+                    }
+                    ((GlTFMaterialDto)entity.dto).extensions.KHR_texture_transform.offset = offset;
+                    break;
+
+                case UMI3DPropertyKeys.TextureTilingScale:
+                    var scale = (SerializableVector2)property.value;
+                    foreach (string textureName in materialToModify.GetTexturePropertyNames())
+                    {
+                        materialToModify.SetTextureScale(textureName, scale);
+                    }
+                    ((GlTFMaterialDto)entity.dto).extensions.KHR_texture_transform.scale = scale;
+                    break;
+
+                case UMI3DPropertyKeys.NormalTextureScale:
+                    materialToModify.ApplyShaderProperty(MRTKShaderUtils.NormalMapScale, (float)(double)property.value);
+                    ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).normalTexture.scale = (float)(double)property.value;
+                    break;
+
+                case UMI3DPropertyKeys.HeightTextureScale:
+                    //Debug.LogWarning("Height Texture not supported");
+                    AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.BumpMap, materialToModify);
+                    ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).heightTexture = (ScalableTextureDto)property.value;
+                    break;
+
+                case UMI3DPropertyKeys.ShaderProperties:
+                    Debug.LogWarning("not totaly implemented");
+                    var extension = ((GlTFMaterialDto)entity.dto).extensions.umi3d;
+                    switch (property)
+                    {
+                        case SetEntityDictionaryAddPropertyDto p:
+                            //  string key = (string)p.key;
+                            if (extension.shaderProperties.ContainsKey((string)p.key))
+                            {
+                                extension.shaderProperties[(string)p.key] = p.value;
+                                Debug.LogWarning("this key (" + p.key.ToString() + ") already exists. Update old value");
+                            }
+                            else
+                                extension.shaderProperties.Add((string)p.key, p.value);
+                            break;
+                        case SetEntityDictionaryRemovePropertyDto p:
+                            extension.shaderProperties.Remove((string)p.key);
+                            Debug.LogWarning("Warning a property is removed but it cannot be applied");
+                            break;
+                        case SetEntityDictionaryPropertyDto p:
+                            extension.shaderProperties[(string)p.key] = p.value;
+                            break;
+                        case SetEntityPropertyDto p:
+                            extension.shaderProperties = (Dictionary<string, object>)p.value;
+                            break;
+
+                        default:
+                            break;
+                    }
+                    if (materialToModify != null)
+                        AbstractUMI3DMaterialLoader.ReadAdditionalShaderProperties(extension.shaderProperties, materialToModify);
+
+                    break;
+
+                default:
+                    return false;
+
+            }
+
+            return true;
+        }
+
         public bool SetUMI3DMaterialProperty(UMI3DEntityInstance entity, SetEntityPropertyDto property)
         {
             if (entity != null && entity.Object is Material)
             {
-                // Debug.Log("change mat property");
-                switch (property.property)
-                {
-                    case UMI3DPropertyKeys.RoughnessFactor:
-                //        ((Material)entity.Object).SetFloat("_Roughness", (float)(double)property.value);
-                  //      ((Material)entity.Object).SetFloat("_Smoothness", RoughnessToSmoothness((float)(double)property.value)); 
-                        ((Material)entity.Object).ApplyShaderProperty(MRTKShaderUtils.Smoothness, RoughnessToSmoothness((float)(double)property.value)); 
-
-                        ((GlTFMaterialDto)entity.dto).pbrMetallicRoughness.roughnessFactor = (float)(double)property.value;
-                        break;
-
-                    case UMI3DPropertyKeys.MetallicFactor:
-                        ((Material)entity.Object).ApplyShaderProperty(MRTKShaderUtils.Metallic, (float)(double)property.value);
-                        ((GlTFMaterialDto)entity.dto).pbrMetallicRoughness.metallicFactor = (float)(double)property.value;
-                        break;
-
-                    case UMI3DPropertyKeys.BaseColorFactor:
-                        ((Material)entity.Object).color = ((SerializableColor)property.value);
-                        ((GlTFMaterialDto)entity.dto).pbrMetallicRoughness.baseColorFactor = (SerializableColor)property.value;
-                        break;
-
-                    case UMI3DPropertyKeys.EmissiveFactor:
-                        ((Material)entity.Object).ApplyShaderProperty(MRTKShaderUtils.EmissiveColor, ((SerializableColor)property.value));
-                        ((GlTFMaterialDto)entity.dto).emissiveFactor = (Vector3)(Vector4)(Color)(SerializableColor)property.value;
-                        break;
-
-                    case UMI3DPropertyKeys.Maintexture:
-                        AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.MainTex, (Material)entity.Object);
-                       ((UMI3DMaterialDto) ((GlTFMaterialDto)entity.dto).extensions.umi3d).baseColorTexture = (TextureDto)property.value;
-                        break;
-
-                    case UMI3DPropertyKeys.NormalTexture:
-                        AbstractUMI3DMaterialLoader.LoadTextureInMaterial((ScalableTextureDto)property.value, MRTKShaderUtils.NormalMap, (Material)entity.Object);
-                        ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).normalTexture = (ScalableTextureDto)property.value;
-                        break;
-
-                    case UMI3DPropertyKeys.EmissiveTexture:
-                        AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.EmissionMap, (Material)entity.Object);
-                        ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).emissiveTexture = (TextureDto)property.value;
-                        break;
-
-                    case UMI3DPropertyKeys.RoughnessTexture:
-                        AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.RoughnessMap, (Material)entity.Object);
-                        ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).roughnessTexture = (TextureDto)property.value;
-                        break;
-
-                    case UMI3DPropertyKeys.MetallicTexture:
-                        AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.MetallicMap, (Material)entity.Object);
-                        ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).metallicTexture = (TextureDto)property.value;
-                        break;
-                    
-                    case UMI3DPropertyKeys.ChannelTexture:
-                        AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.ChannelMap, (Material)entity.Object);
-                        ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).channelTexture = (TextureDto)property.value;
-                        break;
-
-                    case UMI3DPropertyKeys.MetallicRoughnessTexture:
-                        AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.MetallicMap, (Material)entity.Object);
-                        AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.RoughnessMap, (Material)entity.Object);
-                        ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).metallicRoughnessTexture = (TextureDto)property.value;
-                        
-                        break;
-                        
-                    case UMI3DPropertyKeys.OcclusionTexture:
-                        AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.OcclusionMap, (Material)entity.Object);
-                        ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).occlusionTexture = (TextureDto)property.value;
-                        break;
-
-                    case UMI3DPropertyKeys.HeightTexture:
-                        Debug.LogWarning("Height Texture not supported");
-                        break;
-
-                    case UMI3DPropertyKeys.TextureTilingOffset:
-                        Vector2 offset = (SerializableVector2)property.value;
-                        foreach (string textureName in ((Material)entity.Object).GetTexturePropertyNames())
-                        {
-                            ((Material)entity.Object).SetTextureOffset(textureName, offset);
-                        }
-                        ((GlTFMaterialDto)entity.dto).extensions.KHR_texture_transform.offset = offset;
-                        break;
-
-                    case UMI3DPropertyKeys.TextureTilingScale:
-                        var scale = (SerializableVector2)property.value;
-                        foreach (string textureName in ((Material)entity.Object).GetTexturePropertyNames())
-                        {
-                            ((Material)entity.Object).SetTextureScale(textureName, scale);
-                        }
-                        ((GlTFMaterialDto)entity.dto).extensions.KHR_texture_transform.scale = scale;
-                        break;
-
-                    case UMI3DPropertyKeys.NormalTextureScale:
-                        ((Material)entity.Object).ApplyShaderProperty(MRTKShaderUtils.NormalMapScale, (float)(double)property.value);
-                        ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).normalTexture.scale = (float)(double)property.value;
-                        break;
-
-                    case UMI3DPropertyKeys.HeightTextureScale:
-                        //Debug.LogWarning("Height Texture not supported");
-                        AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.BumpMap, (Material)entity.Object);
-                        ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).heightTexture = (ScalableTextureDto)property.value;
-                        break;
-
-
-                    case UMI3DPropertyKeys.ShaderProperties:
-                        Debug.LogWarning("not totaly implemented");
-                        var extension = ((GlTFMaterialDto)entity.dto).extensions.umi3d;
-                        switch (property)
-                        {
-                            case SetEntityDictionaryAddPropertyDto p:
-                                //  string key = (string)p.key;
-                                if (extension.shaderProperties.ContainsKey((string)p.key))
-                                {
-                                    extension.shaderProperties[(string)p.key] = p.value;
-                                    Debug.LogWarning("this key (" + p.key.ToString() + ") already exists. Update old value");
-                                }
-                                else
-                                    extension.shaderProperties.Add((string)p.key, p.value);
-                                break;
-                            case SetEntityDictionaryRemovePropertyDto p:
-                                extension.shaderProperties.Remove((string)p.key);
-                                Debug.LogWarning("Warning a property is removed but it cannot be applied");
-                                break;
-                            case SetEntityDictionaryPropertyDto p:
-                                extension.shaderProperties[(string)p.key] = p.value;
-                                break;
-                            case SetEntityPropertyDto p:
-                                extension.shaderProperties = (Dictionary<string, object>)p.value;
-                                break;
-
-                            default:
-                                break;
-                        }
-                        if((Material)entity.Object != null)
-                            AbstractUMI3DMaterialLoader.ReadAdditionalShaderProperties(extension.shaderProperties, (Material)entity.Object);
-
-                        break;
-
-
-                    default:
-                        return false;
-
-                }
-                return true;
+                return SwitchOnMaterialProperties(entity, property, (Material)entity.Object);
             }
 
             if (entity != null && entity.Object is List<Material>)
             {
+                bool res = false;
                 foreach (Material item in (List<Material>)entity.Object)
                 {
 
-                    //TODO Refacto 
-
-                    switch (property.property)
-                    {
-                        case UMI3DPropertyKeys.RoughnessFactor:
-                            //        ((Material)entity.Object).SetFloat("_Roughness", (float)(double)property.value);
-                            //      ((Material)entity.Object).SetFloat("_Smoothness", RoughnessToSmoothness((float)(double)property.value)); 
-                            item.ApplyShaderProperty(MRTKShaderUtils.Smoothness, RoughnessToSmoothness((float)(double)property.value));
-
-                            ((GlTFMaterialDto)entity.dto).pbrMetallicRoughness.roughnessFactor = (float)(double)property.value;
-                            break;
-
-                        case UMI3DPropertyKeys.MetallicFactor:
-                            item.ApplyShaderProperty(MRTKShaderUtils.Metallic, (float)(double)property.value);
-                            ((GlTFMaterialDto)entity.dto).pbrMetallicRoughness.metallicFactor = (float)(double)property.value;
-                            break;
-
-                        case UMI3DPropertyKeys.BaseColorFactor:
-                            item.color = ((SerializableColor)property.value);
-                            ((GlTFMaterialDto)entity.dto).pbrMetallicRoughness.baseColorFactor = (SerializableColor)property.value;
-                            break;
-
-                        case UMI3DPropertyKeys.EmissiveFactor:
-                            item.ApplyShaderProperty(MRTKShaderUtils.EmissiveColor, ((SerializableColor)property.value));
-                            ((GlTFMaterialDto)entity.dto).emissiveFactor = (Vector3)(Vector4)(Color)(SerializableColor)property.value;
-                            break;
-
-                        case UMI3DPropertyKeys.Maintexture:
-                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.MainTex, item);
-                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).baseColorTexture = (TextureDto)property.value;
-                            break;
-
-                        case UMI3DPropertyKeys.NormalTexture:
-                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((ScalableTextureDto)property.value, MRTKShaderUtils.NormalMap, item);
-                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).normalTexture = (ScalableTextureDto)property.value;
-                            break;
-
-                        case UMI3DPropertyKeys.EmissiveTexture:
-                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.EmissionMap, item);
-                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).emissiveTexture = (TextureDto)property.value;
-                            break;
-
-                        case UMI3DPropertyKeys.RoughnessTexture:
-                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.RoughnessMap, item);
-                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).roughnessTexture = (TextureDto)property.value;
-                            break;
-
-                        case UMI3DPropertyKeys.MetallicTexture:
-                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.MetallicMap, item);
-                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).metallicTexture = (TextureDto)property.value;
-                            break;
-
-                        case UMI3DPropertyKeys.ChannelTexture:
-                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.ChannelMap, item);
-                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).channelTexture = (TextureDto)property.value;
-                            break;
-
-                        case UMI3DPropertyKeys.MetallicRoughnessTexture:
-                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.MetallicMap, item);
-                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.RoughnessMap, item);
-                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).metallicRoughnessTexture = (TextureDto)property.value;
-
-                            break;
-
-                        case UMI3DPropertyKeys.OcclusionTexture:
-                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.OcclusionMap, item);
-                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).occlusionTexture = (TextureDto)property.value;
-                            break;
-
-                        case UMI3DPropertyKeys.HeightTexture:
-                            Debug.LogWarning("Height Texture not supported");
-                            break;
-
-                        case UMI3DPropertyKeys.TextureTilingOffset:
-                            Vector2 offset = (SerializableVector2)property.value;
-                            foreach (string textureName in item.GetTexturePropertyNames())
-                            {
-                                item.SetTextureOffset(textureName, offset);
-                            }
-                            ((GlTFMaterialDto)entity.dto).extensions.KHR_texture_transform.offset = offset;
-                            break;
-
-                        case UMI3DPropertyKeys.TextureTilingScale:
-                            var scale = (SerializableVector2)property.value;
-                            foreach (string textureName in item.GetTexturePropertyNames())
-                            {
-                                item.SetTextureScale(textureName, scale);
-                            }
-                            ((GlTFMaterialDto)entity.dto).extensions.KHR_texture_transform.scale = scale;
-                            break;
-
-                        case UMI3DPropertyKeys.NormalTextureScale:
-                            item.ApplyShaderProperty(MRTKShaderUtils.NormalMapScale, (float)(double)property.value);
-                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).normalTexture.scale = (float)(double)property.value;
-                            break;
-
-                        case UMI3DPropertyKeys.HeightTextureScale:
-                            //Debug.LogWarning("Height Texture not supported");
-                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.BumpMap, item);
-                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).heightTexture = (ScalableTextureDto)property.value;
-                            break;
-
-
-                        case UMI3DPropertyKeys.ShaderProperties:
-                            Debug.LogWarning("not totaly implemented");
-                            var extension = ((GlTFMaterialDto)entity.dto).extensions.umi3d;
-                            switch (property)
-                            {
-                                case SetEntityDictionaryAddPropertyDto p:
-                                    //  string key = (string)p.key;
-                                    if (extension.shaderProperties.ContainsKey((string)p.key))
-                                    {
-                                        extension.shaderProperties[(string)p.key] = p.value;
-                                        Debug.LogWarning("this key (" + p.key.ToString() + ") already exists. Update old value");
-                                    }
-                                    else
-                                        extension.shaderProperties.Add((string)p.key, p.value);
-                                    break;
-                                case SetEntityDictionaryRemovePropertyDto p:
-                                    extension.shaderProperties.Remove((string)p.key);
-                                    Debug.LogWarning("Warning a property is removed but it cannot be applied");
-                                    break;
-                                case SetEntityDictionaryPropertyDto p:
-                                    extension.shaderProperties[(string)p.key] = p.value;
-                                    break;
-                                case SetEntityPropertyDto p:
-                                    extension.shaderProperties = (Dictionary<string, object>)p.value;
-                                    break;
-
-                                default:
-                                    break;
-                            }
-                            if (item != null)
-                                AbstractUMI3DMaterialLoader.ReadAdditionalShaderProperties(extension.shaderProperties, item);
-
-                            break;
-
-
-                        default:
-                            return false;
-
-                    }
+                    if (SwitchOnMaterialProperties(entity, property, item))
+                        res = true;
                 }
-                return true;
-
-
+                return res;
             }
-
-
             return false;
         }
-
-
     }
 
 }

--- a/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/UMI3DSceneLoader.cs
+++ b/UMI3D-SDK/Assets/ClientDevelopmentKit/Core/Runtime/Loaders/UMI3DSceneLoader.cs
@@ -123,7 +123,7 @@ namespace umi3d.cdk
 
                     UMI3DEnvironmentLoader.Parameters.SelectMaterialLoader(material).LoadMaterialFromExtension(material, (m) =>
                     {
-                        if (material.name != null && material.name.Length > 0)
+                        if (material.name != null && material.name.Length > 0 && m != null)
                             m.name = material.name;
                         //register the material
                         UMI3DEntityInstance entity = UMI3DEnvironmentLoader.RegisterEntityInstance(((AbstractEntityDto)material.extensions.umi3d).id, material, m);
@@ -279,8 +279,8 @@ namespace umi3d.cdk
                             default:
                                 break;
                         }
-
-                        AbstractUMI3DMaterialLoader.ReadAdditionalShaderProperties(extension.shaderProperties, (Material)entity.Object);
+                        if((Material)entity.Object != null)
+                            AbstractUMI3DMaterialLoader.ReadAdditionalShaderProperties(extension.shaderProperties, (Material)entity.Object);
 
                         break;
 
@@ -290,6 +290,159 @@ namespace umi3d.cdk
 
                 }
                 return true;
+            }
+
+            if (entity != null && entity.Object is List<Material>)
+            {
+                foreach (Material item in (List<Material>)entity.Object)
+                {
+
+                    //TODO Refacto 
+
+                    switch (property.property)
+                    {
+                        case UMI3DPropertyKeys.RoughnessFactor:
+                            //        ((Material)entity.Object).SetFloat("_Roughness", (float)(double)property.value);
+                            //      ((Material)entity.Object).SetFloat("_Smoothness", RoughnessToSmoothness((float)(double)property.value)); 
+                            item.ApplyShaderProperty(MRTKShaderUtils.Smoothness, RoughnessToSmoothness((float)(double)property.value));
+
+                            ((GlTFMaterialDto)entity.dto).pbrMetallicRoughness.roughnessFactor = (float)(double)property.value;
+                            break;
+
+                        case UMI3DPropertyKeys.MetallicFactor:
+                            item.ApplyShaderProperty(MRTKShaderUtils.Metallic, (float)(double)property.value);
+                            ((GlTFMaterialDto)entity.dto).pbrMetallicRoughness.metallicFactor = (float)(double)property.value;
+                            break;
+
+                        case UMI3DPropertyKeys.BaseColorFactor:
+                            item.color = ((SerializableColor)property.value);
+                            ((GlTFMaterialDto)entity.dto).pbrMetallicRoughness.baseColorFactor = (SerializableColor)property.value;
+                            break;
+
+                        case UMI3DPropertyKeys.EmissiveFactor:
+                            item.ApplyShaderProperty(MRTKShaderUtils.EmissiveColor, ((SerializableColor)property.value));
+                            ((GlTFMaterialDto)entity.dto).emissiveFactor = (Vector3)(Vector4)(Color)(SerializableColor)property.value;
+                            break;
+
+                        case UMI3DPropertyKeys.Maintexture:
+                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.MainTex, item);
+                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).baseColorTexture = (TextureDto)property.value;
+                            break;
+
+                        case UMI3DPropertyKeys.NormalTexture:
+                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((ScalableTextureDto)property.value, MRTKShaderUtils.NormalMap, item);
+                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).normalTexture = (ScalableTextureDto)property.value;
+                            break;
+
+                        case UMI3DPropertyKeys.EmissiveTexture:
+                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.EmissionMap, item);
+                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).emissiveTexture = (TextureDto)property.value;
+                            break;
+
+                        case UMI3DPropertyKeys.RoughnessTexture:
+                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.RoughnessMap, item);
+                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).roughnessTexture = (TextureDto)property.value;
+                            break;
+
+                        case UMI3DPropertyKeys.MetallicTexture:
+                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.MetallicMap, item);
+                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).metallicTexture = (TextureDto)property.value;
+                            break;
+
+                        case UMI3DPropertyKeys.ChannelTexture:
+                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.ChannelMap, item);
+                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).channelTexture = (TextureDto)property.value;
+                            break;
+
+                        case UMI3DPropertyKeys.MetallicRoughnessTexture:
+                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.MetallicMap, item);
+                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.RoughnessMap, item);
+                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).metallicRoughnessTexture = (TextureDto)property.value;
+
+                            break;
+
+                        case UMI3DPropertyKeys.OcclusionTexture:
+                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.OcclusionMap, item);
+                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).occlusionTexture = (TextureDto)property.value;
+                            break;
+
+                        case UMI3DPropertyKeys.HeightTexture:
+                            Debug.LogWarning("Height Texture not supported");
+                            break;
+
+                        case UMI3DPropertyKeys.TextureTilingOffset:
+                            Vector2 offset = (SerializableVector2)property.value;
+                            foreach (string textureName in item.GetTexturePropertyNames())
+                            {
+                                item.SetTextureOffset(textureName, offset);
+                            }
+                            ((GlTFMaterialDto)entity.dto).extensions.KHR_texture_transform.offset = offset;
+                            break;
+
+                        case UMI3DPropertyKeys.TextureTilingScale:
+                            var scale = (SerializableVector2)property.value;
+                            foreach (string textureName in item.GetTexturePropertyNames())
+                            {
+                                item.SetTextureScale(textureName, scale);
+                            }
+                            ((GlTFMaterialDto)entity.dto).extensions.KHR_texture_transform.scale = scale;
+                            break;
+
+                        case UMI3DPropertyKeys.NormalTextureScale:
+                            item.ApplyShaderProperty(MRTKShaderUtils.NormalMapScale, (float)(double)property.value);
+                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).normalTexture.scale = (float)(double)property.value;
+                            break;
+
+                        case UMI3DPropertyKeys.HeightTextureScale:
+                            //Debug.LogWarning("Height Texture not supported");
+                            AbstractUMI3DMaterialLoader.LoadTextureInMaterial((TextureDto)property.value, MRTKShaderUtils.BumpMap, item);
+                            ((UMI3DMaterialDto)((GlTFMaterialDto)entity.dto).extensions.umi3d).heightTexture = (ScalableTextureDto)property.value;
+                            break;
+
+
+                        case UMI3DPropertyKeys.ShaderProperties:
+                            Debug.LogWarning("not totaly implemented");
+                            var extension = ((GlTFMaterialDto)entity.dto).extensions.umi3d;
+                            switch (property)
+                            {
+                                case SetEntityDictionaryAddPropertyDto p:
+                                    //  string key = (string)p.key;
+                                    if (extension.shaderProperties.ContainsKey((string)p.key))
+                                    {
+                                        extension.shaderProperties[(string)p.key] = p.value;
+                                        Debug.LogWarning("this key (" + p.key.ToString() + ") already exists. Update old value");
+                                    }
+                                    else
+                                        extension.shaderProperties.Add((string)p.key, p.value);
+                                    break;
+                                case SetEntityDictionaryRemovePropertyDto p:
+                                    extension.shaderProperties.Remove((string)p.key);
+                                    Debug.LogWarning("Warning a property is removed but it cannot be applied");
+                                    break;
+                                case SetEntityDictionaryPropertyDto p:
+                                    extension.shaderProperties[(string)p.key] = p.value;
+                                    break;
+                                case SetEntityPropertyDto p:
+                                    extension.shaderProperties = (Dictionary<string, object>)p.value;
+                                    break;
+
+                                default:
+                                    break;
+                            }
+                            if (item != null)
+                                AbstractUMI3DMaterialLoader.ReadAdditionalShaderProperties(extension.shaderProperties, item);
+
+                            break;
+
+
+                        default:
+                            return false;
+
+                    }
+                }
+                return true;
+
+
             }
 
 

--- a/UMI3D-SDK/Assets/Common/Core/Runtime/Dto/UMI3DContent/UMI3DOriginalMaterialDto.cs
+++ b/UMI3D-SDK/Assets/Common/Core/Runtime/Dto/UMI3DContent/UMI3DOriginalMaterialDto.cs
@@ -1,0 +1,26 @@
+﻿/*
+Copyright 2019 Gfi Informatique
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+namespace umi3d.common
+{
+    [System.Serializable]
+    public class UMI3DOriginalMaterialDto : AbstractEntityDto, IMaterialDto
+    {
+        public Dictionary<string, object> shaderProperties { get; set; }
+    }
+}

--- a/UMI3D-SDK/Assets/Common/Core/Runtime/Dto/UMI3DContent/UMI3DOriginalMaterialDto.cs.meta
+++ b/UMI3D-SDK/Assets/Common/Core/Runtime/Dto/UMI3DContent/UMI3DOriginalMaterialDto.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ba85a2b70019e5243ad456384d8dc4a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/Dependencies/Runtime/LoaderUtils/Runtime/UMI3DBaseMaterial.mat
+++ b/UMI3D-SDK/Assets/Dependencies/Runtime/LoaderUtils/Runtime/UMI3DBaseMaterial.mat
@@ -73,7 +73,7 @@ Material:
     - _AlbedoAlphaMode: 0
     - _AlbedoAssignedAtRuntime: 0
     - _BlendOp: 0
-    - _BlendedClippingWidth: 1
+    - _BlendedClippingWidth: 0.2
     - _BorderLight: 0
     - _BorderLightOpaque: 0
     - _BorderLightOpaqueAlpha: 1

--- a/UMI3D-SDK/Assets/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/MaterialSO.cs
+++ b/UMI3D-SDK/Assets/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/MaterialSO.cs
@@ -23,6 +23,12 @@ namespace umi3d.edk
     public abstract class MaterialSO : ScriptableObject, UMI3DLoadableEntity
     {
 
+
+        public Dictionary<string, object> shaderProperties = new Dictionary<string, object>();
+        public UMI3DAsyncDictionnaryProperty<string, object> objectShaderProperties { get { Id(); return _objectShaderProperties; } protected set => _objectShaderProperties = value; }
+
+        private UMI3DAsyncDictionnaryProperty<string, object> _objectShaderProperties;
+
         public enum AlphaMode
         {
             OPAQUE, MASK, BLEND

--- a/UMI3D-SDK/Assets/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/OriginalMaterial.cs
+++ b/UMI3D-SDK/Assets/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/OriginalMaterial.cs
@@ -19,25 +19,23 @@ using UnityEngine;
 
 namespace umi3d.edk
 {
-    [CreateAssetMenu(fileName = "Umi3D_External_Material", menuName = "UMI3D/Umi3D_External_Material")]
-    public class ExternalResourceMaterial : MaterialSO
+    [CreateAssetMenu(fileName = "Umi3D_Original_Material", menuName = "UMI3D/Umi3D_Original_Material")]
+    public class OriginalMaterial : MaterialSO
     {
 
         public string matId;
-        public UMI3DResource resource;
 
 
-        ///<inheritdoc/>
+        private bool registered = false;
+
         public override GlTFMaterialDto ToDto()
         {
             var res = new GlTFMaterialDto();
             res.extensions = new GlTFMaterialExtensions()
-            { umi3d = new ExternalMaterialDto() };
-            ((ExternalMaterialDto)res.extensions.umi3d).resource = resource.ToDto();
-            ((ExternalMaterialDto)res.extensions.umi3d).id = GetId();
-            ((ExternalMaterialDto)res.extensions.umi3d).shaderProperties = shaderProperties;
+            { umi3d = new UMI3DOriginalMaterialDto() };
+            ((UMI3DOriginalMaterialDto)res.extensions.umi3d).id = GetId();
 
-
+            ((UMI3DOriginalMaterialDto)res.extensions.umi3d).shaderProperties = shaderProperties;
             return res;
         }
 
@@ -47,17 +45,12 @@ namespace umi3d.edk
             return ToDto();
         }
 
-        private bool registered = false;
-
         ///<inheritdoc/>
         protected override string GetId()
         {
-            if (!registered)
+            if(!registered)
             {
-                ExternalMaterialDto matDto = new ExternalMaterialDto()
-                {
-                    resource = resource.ToDto(),
-                };
+                UMI3DOriginalMaterialDto matDto = new UMI3DOriginalMaterialDto();
                 RegisterMaterial(matDto);
             }
             return matId;
@@ -66,7 +59,7 @@ namespace umi3d.edk
         ///<inheritdoc/>
         protected override void InitDefinition(string id)
         {
-            Debug.Log("id external mat " + id);
+            Debug.Log("id original mat " + id);
             objectShaderProperties = new UMI3DAsyncDictionnaryProperty<string, object>(id, UMI3DPropertyKeys.ShaderProperties, this.shaderProperties, null, null, null, (d) =>
             {
                 return new Dictionary<string, object>(d);
@@ -77,9 +70,9 @@ namespace umi3d.edk
             objectShaderProperties.OnValueChanged += (Dictionary<string, object> d) => { shaderProperties = d; };
         }
 
-        ///<inheritdoc/>
         protected override void OnEnable()
         {
+
             matId = null;
             registered = false;
         }
@@ -90,5 +83,7 @@ namespace umi3d.edk
             registered = true;
             matId = id;
         }
+
+
     }
 }

--- a/UMI3D-SDK/Assets/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/OriginalMaterial.cs.meta
+++ b/UMI3D-SDK/Assets/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/OriginalMaterial.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20bcf44aede6fb94b92947f3433cef03
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/PBRMaterial.cs
+++ b/UMI3D-SDK/Assets/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/PBRMaterial.cs
@@ -32,8 +32,6 @@ namespace umi3d.edk
         //   public UMI3DMaterialDto textures;
         public CustomTextures textures = new CustomTextures();
 
-        // list of supported type for object: float, int, vector2-3-4, Color, TextureDto
-        public Dictionary<string, object> shaderProperties = new Dictionary<string, object>();
 
         public Vector2 tilingScale = Vector2.one;
         public Vector2 tilingOffset = Vector2.zero;
@@ -112,7 +110,6 @@ namespace umi3d.edk
         public UMI3DAsyncProperty<Vector2> objectTextureTilingOffset { get { Id(); return _objectTextureTilingOffset; } protected set => _objectTextureTilingOffset = value; }
         public UMI3DAsyncProperty<float> objectNormalTextureScale { get { Id(); return _objectNormalTextureScale; } protected set => _objectNormalTextureScale = value; }
         public UMI3DAsyncProperty<float> objectHeightTextureScale { get { Id(); return _objectHeightTextureScale; } protected set => _objectHeightTextureScale = value; }
-        public UMI3DAsyncDictionnaryProperty<string, object> objectShaderProperties { get { Id(); return _objectShaderProperties; } protected set => _objectShaderProperties = value; } // not totaly implemented
 
         private UMI3DAsyncPropertyEquality pCompare = new UMI3DAsyncPropertyEquality();
 

--- a/UMI3D-SDK/Assets/EnvironmentDevelopmentKit/Core/Runtime/SimpleModificationListener.cs
+++ b/UMI3D-SDK/Assets/EnvironmentDevelopmentKit/Core/Runtime/SimpleModificationListener.cs
@@ -136,6 +136,8 @@ namespace umi3d.edk
                         break;
                     case ExternalResourceMaterial extmat:
                         break;
+                    case OriginalMaterial extmat:
+                        break;
                     default:
                         Debug.LogWarning("unsupported material type");
                         break;


### PR DESCRIPTION
Add original material, allows to modify (on loading and on updates) a property in shader without overriding all the material 