### PR TITLE
Precised navmesh requirements in tooltip

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/UMI3DModel.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/UMI3DModel.cs
@@ -67,7 +67,7 @@ namespace umi3d.edk
         /// <summary>
         /// Should this mesh be used for navmesh generation on the browser?
         /// </summary>
-        [Tooltip("Should this mesh be used for navmesh generation on the browser?")]
+        [Tooltip("Should this mesh be used for navmesh generation on the browser? The model should have a collider.")]
         public bool isPartOfNavmesh = false;
 
         /// <summary>


### PR DESCRIPTION
To properly generate a navmesh it is now necessary to have at least a collider. It is now explained in the isPartOfNavmesh toolitp.