### PR TITLE
Remove CS1998 warnings on Animation API

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Loaders/UMI3DEmoteLoader.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Loaders/UMI3DEmoteLoader.cs
@@ -32,18 +32,19 @@ namespace umi3d.cdk.collaboration
         }
 
         /// <inheritdoc/>
-        public override async Task ReadUMI3DExtension(ReadUMI3DExtensionData value)
+        public override Task ReadUMI3DExtension(ReadUMI3DExtensionData value)
         {
             var dto = value.dto as UMI3DEmoteDto;
             UMI3DEnvironmentLoader.Instance.RegisterEntity(dto.id, dto, null).NotifyLoaded();
             UMI3DCollaborationClientUserTracking.Instance.OnEmoteUpdated(dto);
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc/>
         public override async Task<bool> SetUMI3DProperty(SetUMI3DPropertyData value)
         {
             if (value.entity.dto is not UMI3DEmoteDto dto)
-                return false;
+                return await Task.FromResult(false);
 
             switch (value.property.property)
             {
@@ -58,16 +59,16 @@ namespace umi3d.cdk.collaboration
                     break;
 
                 default:
-                    return false;
+                    return await Task.FromResult(false);
             }
-            return true;
+            return await Task.FromResult(true);
         }
 
         /// <inheritdoc/>
         public override async Task<bool> SetUMI3DProperty(SetUMI3DPropertyContainerData value)
         {
             if (value.entity.dto is not UMI3DEmoteDto dto)
-                return false;
+                return await Task.FromResult(false);
 
             switch (value.propertyKey)
             {
@@ -82,9 +83,9 @@ namespace umi3d.cdk.collaboration
                     break;
 
                 default:
-                    return false;
+                    return await Task.FromResult(false);
             }
-            return true;
+            return await Task.FromResult(true);
         }
 
         /// <summary>
@@ -105,9 +106,9 @@ namespace umi3d.cdk.collaboration
                     break;
 
                 default:
-                    return false;
+                    return await Task.FromResult(false);
             }
-            return true;
+            return await Task.FromResult(true);
         }
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Loaders/UMI3DEmotesConfigLoader.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Loaders/UMI3DEmotesConfigLoader.cs
@@ -33,7 +33,7 @@ namespace umi3d.cdk.collaboration
         }
 
         /// <inheritdoc/>
-        public override async Task ReadUMI3DExtension(ReadUMI3DExtensionData value)
+        public override Task ReadUMI3DExtension(ReadUMI3DExtensionData value)
         {
             var dto = value.dto as UMI3DEmotesConfigDto;
             UMI3DEnvironmentLoader.Instance.RegisterEntity(dto.id, dto, null).NotifyLoaded();
@@ -42,13 +42,14 @@ namespace umi3d.cdk.collaboration
                 UMI3DEnvironmentLoader.Instance.RegisterEntity(emoteDto.id, emoteDto, null).NotifyLoaded();
 
             UMI3DCollaborationClientUserTracking.Instance.OnEmoteConfigLoaded(dto);
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc/>
         public override async Task<bool> SetUMI3DProperty(SetUMI3DPropertyData value)
         {
             if (value.entity.dto is not UMI3DEmotesConfigDto dto)
-                return false;
+                return await Task.FromResult(false);
 
             switch (value.property.property)
             {
@@ -58,16 +59,16 @@ namespace umi3d.cdk.collaboration
                     break;
 
                 default:
-                    return false;
+                    return await Task.FromResult(false);
             }
-            return true;
+            return await Task.FromResult(true);
         }
 
         /// <inheritdoc/>
         public override async Task<bool> SetUMI3DProperty(SetUMI3DPropertyContainerData value)
         {
             if (value.entity.dto is not UMI3DEmotesConfigDto dto)
-                return false;
+                return await Task.FromResult(false);
 
             switch (value.propertyKey)
             {
@@ -77,9 +78,9 @@ namespace umi3d.cdk.collaboration
                     break;
 
                 default:
-                    return false;
+                    return await Task.FromResult(false);
             }
-            return true;
+            return await Task.FromResult(true);
         }
 
         /// <inheritdoc/>
@@ -93,9 +94,9 @@ namespace umi3d.cdk.collaboration
                     break;
 
                 default:
-                    return false;
+                    return await Task.FromResult(false);
             }
-            return true;
+            return await Task.FromResult(true);
         }
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/UMI3DAbstractAnimation.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/UMI3DAbstractAnimation.cs
@@ -117,9 +117,9 @@ namespace umi3d.cdk
                     SetProgress(dto.pauseTime);
                     break;
                 default:
-                    return false;
+                    return await Task.FromResult(false);
             }
-            return true;
+            return await Task.FromResult(true);
         }
 
         /// <inheritdoc/>
@@ -164,9 +164,9 @@ namespace umi3d.cdk
                     SetProgress(dto.pauseTime);
                     break;
                 default:
-                    return false;
+                    return await Task.FromResult(false);
             }
-            return true;
+            return await Task.FromResult(true);
         }
 
         /// <summary>

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/UMI3DAnimation.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/UMI3DAnimation.cs
@@ -170,10 +170,10 @@ namespace umi3d.cdk
                 case UMI3DPropertyKeys.AnimationChain:
                     return UpdateChain(value);
                 default:
-                    return false;
+                    return await Task.FromResult(false);
             }
 
-            return true;
+            return await Task.FromResult(true);
         }
 
         private static bool UpdateChain(ReadUMI3DPropertyData value)

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Loaders/UMI3DAnimationLoader.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Loaders/UMI3DAnimationLoader.cs
@@ -35,7 +35,7 @@ namespace umi3d.cdk
         }
 
         /// <inheritdoc/>
-        public override async Task ReadUMI3DExtension(ReadUMI3DExtensionData value)
+        public override Task ReadUMI3DExtension(ReadUMI3DExtensionData value)
         {
             UMI3DAbstractAnimation animationInstance = value.dto switch
             {
@@ -51,7 +51,8 @@ namespace umi3d.cdk
             {
                 UMI3DEnvironmentLoader.Instance.RegisterEntity(animationInstance.Id, value.dto, animationInstance).NotifyLoaded();
                 animationInstance.Init();
-            }    
+            }
+            return Task.CompletedTask;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Some async methods were not really async and it was triggering the CS1998 warning. Solved by :
- Remove async keyword when unnecessary and added Task.CompletedTask.
- Added await Tsk.FromResult() when possible