### PR TITLE
Remove emotes from clientUserTracking

### DIFF
--- a/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/Collaboration/EmoteManager_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/Collaboration/EmoteManager_Test.cs
@@ -36,7 +36,6 @@ namespace EditMode_Tests
             environmentLoaderServiceMock = new Mock<UMI3DEnvironmentLoader>();
 
             emoteManagerService = new EmoteManager(environmentLoaderServiceMock.Object);
-            emoteManagerService.Initialize(null);
         }
 
         [TearDown]
@@ -48,6 +47,31 @@ namespace EditMode_Tests
             if (UMI3DEnvironmentLoader.Exists)
                 UMI3DEnvironmentLoader.Destroy();
         }
+
+        #region UpdateEmote
+
+        [Test]
+        public void Test_UpdateEmote_NotReceivedEmote()
+        {
+            // GIVEN
+            UMI3DEmoteDto emoteDto = new()
+            {
+                id = 0,
+                animationId = 0,
+                label = ""
+            };
+
+            bool wasEmoteUpdatedTriggered = false;
+            emoteManagerService.EmoteUpdated += delegate { wasEmoteUpdatedTriggered = true; };
+
+            // WHEN
+            emoteManagerService.UpdateEmote(emoteDto);
+
+            // THEN
+            Assert.IsFalse(wasEmoteUpdatedTriggered);
+        }
+
+        #endregion UpdateEmote
 
         #region PlayEmote
 

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK.meta
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 15febb85cd01de0449236808f7d5ba8b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration.meta
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b36a7ee5f288314eb4be55ce0812593
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/EmoteManager_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/EmoteManager_Test.cs
@@ -1,0 +1,174 @@
+﻿/*
+Copyright 2019 - 2023 Inetum
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Moq;
+using NUnit.Framework;
+using umi3d.cdk;
+using umi3d.cdk.collaboration;
+using umi3d.common.collaboration;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.TestTools;
+
+namespace PlayMode_Tests
+{
+    public class EmoteManager_Test
+    {
+        private const string TEST_SCENE_NAME = "Tests/PlayMode_Tests/TestScenes/TESTSCENE_Empty";
+
+        private EmoteManager emoteManagerService;
+
+        private Mock<UMI3DEnvironmentLoader> environmentLoaderServiceMock;
+
+        [SetUp]
+        public void SetUp()
+        {
+            SceneManager.LoadScene(TEST_SCENE_NAME);
+            GameObject go = new GameObject("CollabServer");
+            UnityEngine.Object.Instantiate(go);
+
+            UMI3DCollaborationClientServer clientServer = go.AddComponent<UMI3DCollaborationClientServer>();
+
+            Debug.Log(clientServer);
+
+            environmentLoaderServiceMock = new Mock<UMI3DEnvironmentLoader>();
+
+            emoteManagerService = new EmoteManager(environmentLoaderServiceMock.Object);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (EmoteManager.Exists)
+                EmoteManager.Destroy();
+
+            if (UMI3DEnvironmentLoader.Exists)
+                UMI3DEnvironmentLoader.Destroy();
+        }
+
+        [UnityTearDown]
+        public void UnityTearDown()
+        {
+            SceneManager.UnloadSceneAsync(TEST_SCENE_NAME);
+
+            if (UMI3DClientServer.Exists)
+                UMI3DClientServer.Destroy();
+
+            if (UMI3DCollaborationClientServer.Exists)
+                UMI3DCollaborationClientServer.Destroy();
+        }
+
+        #region LoadEmoteConfig
+
+        // Playmode because of use of UMI3DCollaborationClientServer
+        [Test]
+        public void Test_LoadEmoteConfig_Empty()
+        {
+            // GIVEN
+            UMI3DEmotesConfigDto dto = new()
+            {
+                id = 1,
+                emotes = new(),
+                allAvailableByDefault = false
+            };
+
+            bool wasEmotesLoaded = false;
+            emoteManagerService.EmotesLoaded += delegate { wasEmotesLoaded = true; };
+
+            // WHEN
+            emoteManagerService.LoadEmoteConfig(dto);
+            environmentLoaderServiceMock.Object.onEnvironmentLoaded.Invoke();
+
+            // THEN
+            Assert.IsTrue(wasEmotesLoaded);
+            Assert.IsEmpty(emoteManagerService.Emotes);
+        }
+
+        [Test]
+        public void Test_LoadEmoteConfig_SeveralEmotes()
+        {
+            // GIVEN
+            UMI3DEmotesConfigDto dto = new()
+            {
+                id = 1,
+                emotes = new()
+                {
+                    new UMI3DEmoteDto()
+                    {
+                        id = 2,
+                        available = true
+                    },
+                    new UMI3DEmoteDto()
+                    {
+                        id = 3,
+                        available = false
+                    }
+                },
+                allAvailableByDefault = false
+            };
+
+            bool wasEmotesLoaded = false;
+            emoteManagerService.EmotesLoaded += delegate { wasEmotesLoaded = true; };
+
+            // WHEN
+            emoteManagerService.LoadEmoteConfig(dto);
+            environmentLoaderServiceMock.Object.onEnvironmentLoaded.Invoke();
+
+            // THEN
+            Assert.IsTrue(wasEmotesLoaded);
+            Assert.AreEqual(dto.emotes.Count, emoteManagerService.Emotes.Count);
+        }
+
+        [Test]
+        public void Test_LoadEmoteConfig_SeveralEmotes_AllAvailableOverride()
+        {
+            // GIVEN
+            UMI3DEmotesConfigDto dto = new()
+            {
+                id = 1,
+                emotes = new()
+                {
+                    new UMI3DEmoteDto()
+                    {
+                        id = 2,
+                        available = false
+                    },
+                    new UMI3DEmoteDto()
+                    {
+                        id = 3,
+                        available = false
+                    }
+                },
+                allAvailableByDefault = true
+            };
+
+            bool wasEmotesLoaded = false;
+            emoteManagerService.EmotesLoaded += delegate { wasEmotesLoaded = true; };
+
+            // WHEN
+            emoteManagerService.LoadEmoteConfig(dto);
+            environmentLoaderServiceMock.Object.onEnvironmentLoaded.Invoke();
+
+            // THEN
+            Assert.IsTrue(wasEmotesLoaded);
+            Assert.AreEqual(dto.emotes.Count, emoteManagerService.Emotes.Count);
+            foreach (var emote in emoteManagerService.Emotes)
+                Assert.IsTrue(emote.available);
+        }
+
+        #endregion LoadEmoteConfig
+    }
+}

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/EmoteManager_Test.cs.meta
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/EmoteManager_Test.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 997461c763da0154f8f385bb91cea173
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/ISkeleton_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/ISkeleton_Test.cs
@@ -87,7 +87,7 @@ public class ISkeleton_Test
     [UnityTearDown]
     public void TearDown()
     {
-
+        SceneManager.UnloadSceneAsync("Tests/PlayMode_Tests/TestScenes/TESTSCENE_Bindings");
     }
 
     #region Bindings

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/TestScenes/TESTSCENE_Empty.unity
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/TestScenes/TESTSCENE_Empty.unity
@@ -1,0 +1,303 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &141677813
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 141677815}
+  - component: {fileID: 141677814}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &141677814
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 141677813}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &141677815
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 141677813}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1145328019
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1145328022}
+  - component: {fileID: 1145328021}
+  - component: {fileID: 1145328020}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1145328020
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1145328019}
+  m_Enabled: 1
+--- !u!20 &1145328021
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1145328019}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1145328022
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1145328019}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/TestScenes/TESTSCENE_Empty.unity.meta
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/TestScenes/TESTSCENE_Empty.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5e8cf43c8408df14fb8786a068d215a1
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Loaders/UMI3DEmoteLoader.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Loaders/UMI3DEmoteLoader.cs
@@ -25,6 +25,21 @@ namespace umi3d.cdk.collaboration
         private UMI3DVersion.VersionCompatibility _version = new UMI3DVersion.VersionCompatibility("2.6", "*");
         public override UMI3DVersion.VersionCompatibility version => _version;
 
+        #region DependencyInjection
+        private EmoteManager emoteManagementService;
+
+        public UMI3DEmoteLoader()
+        {
+            emoteManagementService = EmoteManager.Instance;
+        }
+
+
+        public UMI3DEmoteLoader(EmoteManager emoteManager)
+        {
+            emoteManagementService = emoteManager;
+        }
+        #endregion DependencyInjection
+
         /// <inheritdoc/>
         public override bool CanReadUMI3DExtension(ReadUMI3DExtensionData data)
         {
@@ -36,7 +51,7 @@ namespace umi3d.cdk.collaboration
         {
             var dto = value.dto as UMI3DEmoteDto;
             UMI3DEnvironmentLoader.Instance.RegisterEntity(dto.id, dto, null).NotifyLoaded();
-            UMI3DCollaborationClientUserTracking.Instance.OnEmoteUpdated(dto);
+            emoteManagementService.UpdateEmote(dto);
             return Task.CompletedTask;
         }
 
@@ -50,12 +65,12 @@ namespace umi3d.cdk.collaboration
             {
                 case UMI3DPropertyKeys.ActiveEmote:
                     dto.available = (bool)value.property.value;
-                    UMI3DCollaborationClientUserTracking.Instance.OnEmoteUpdated(dto);
+                    emoteManagementService.UpdateEmote(dto);
                     break;
 
                 case UMI3DPropertyKeys.AnimationEmote:
                     dto.animationId = (ulong)value.property.value;
-                    UMI3DCollaborationClientUserTracking.Instance.OnEmoteUpdated(dto);
+                    emoteManagementService.UpdateEmote(dto);
                     break;
 
                 default:
@@ -74,12 +89,12 @@ namespace umi3d.cdk.collaboration
             {
                 case UMI3DPropertyKeys.ActiveEmote:
                     dto.available = UMI3DSerializer.Read<bool>(value.container);
-                    UMI3DCollaborationClientUserTracking.Instance.OnEmoteUpdated(dto);
+                    emoteManagementService.UpdateEmote(dto);
                     break;
 
                 case UMI3DPropertyKeys.AnimationEmote:
                     dto.animationId = UMI3DSerializer.Read<ulong>(value.container);
-                    UMI3DCollaborationClientUserTracking.Instance.OnEmoteUpdated(dto);
+                    emoteManagementService.UpdateEmote(dto);
                     break;
 
                 default:
@@ -102,7 +117,7 @@ namespace umi3d.cdk.collaboration
                 case UMI3DPropertyKeys.ActiveEmote:
                 case UMI3DPropertyKeys.AnimationEmote:
                     data.result = UMI3DSerializer.Read<UMI3DEmoteDto>(data.container);
-                    UMI3DCollaborationClientUserTracking.Instance.OnEmoteUpdated(data.result as UMI3DEmoteDto);
+                    emoteManagementService.UpdateEmote(data.result as UMI3DEmoteDto);
                     break;
 
                 default:

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Loaders/UMI3DEmotesConfigLoader.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Loaders/UMI3DEmotesConfigLoader.cs
@@ -26,6 +26,20 @@ namespace umi3d.cdk.collaboration
         private UMI3DVersion.VersionCompatibility _version = new UMI3DVersion.VersionCompatibility("2.6", "*");
         public override UMI3DVersion.VersionCompatibility version => _version;
 
+        #region DependencyInjection
+        private EmoteManager emoteManagementService;
+
+        public UMI3DEmotesConfigLoader()
+        {
+            emoteManagementService = EmoteManager.Instance;
+        }
+
+        public UMI3DEmotesConfigLoader(EmoteManager emoteManager)
+        {
+            emoteManagementService = emoteManager;
+        }
+        #endregion DependencyInjection
+
         /// <inheritdoc/>
         public override bool CanReadUMI3DExtension(ReadUMI3DExtensionData data)
         {
@@ -41,7 +55,7 @@ namespace umi3d.cdk.collaboration
             foreach (UMI3DEmoteDto emoteDto in dto.emotes)
                 UMI3DEnvironmentLoader.Instance.RegisterEntity(emoteDto.id, emoteDto, null).NotifyLoaded();
 
-            UMI3DCollaborationClientUserTracking.Instance.OnEmoteConfigLoaded(dto);
+            emoteManagementService.LoadEmoteConfig(dto);
             return Task.CompletedTask;
         }
 
@@ -55,7 +69,7 @@ namespace umi3d.cdk.collaboration
             {
                 case UMI3DPropertyKeys.ChangeEmoteConfig:
                     dto.emotes = value.property.value as List<UMI3DEmoteDto>;
-                    UMI3DCollaborationClientUserTracking.Instance.OnEmoteConfigLoaded(dto);
+                    emoteManagementService.LoadEmoteConfig(dto);
                     break;
 
                 default:
@@ -74,7 +88,7 @@ namespace umi3d.cdk.collaboration
             {
                 case UMI3DPropertyKeys.ChangeEmoteConfig:
                     dto.emotes = UMI3DSerializer.Read<List<UMI3DEmoteDto>>(value.container);
-                    UMI3DCollaborationClientUserTracking.Instance.OnEmoteConfigLoaded(dto);
+                    emoteManagementService.LoadEmoteConfig(dto);
                     break;
 
                 default:
@@ -90,7 +104,7 @@ namespace umi3d.cdk.collaboration
             {
                 case UMI3DPropertyKeys.ChangeEmoteConfig:
                     data.result = UMI3DSerializer.Read<UMI3DEmotesConfigDto>(data.container);
-                    UMI3DCollaborationClientUserTracking.Instance.OnEmoteConfigLoaded(data.result as UMI3DEmotesConfigDto);
+                    emoteManagementService.LoadEmoteConfig(data.result as UMI3DEmotesConfigDto);
                     break;
 
                 default:

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/UMI3DCollaborationClientUserTracking.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/UMI3DCollaborationClientUserTracking.cs
@@ -85,26 +85,6 @@ namespace umi3d.cdk.collaboration
             UMI3DCollaborationClientServer.Instance.OnReconnect.AddListener(() => embodimentDict.Clear());
         }
 
-        public class EmotesConfigEvent : UnityEvent<UMI3DEmotesConfigDto> { };
-        public class EmoteEvent : UnityEvent<UMI3DEmoteDto> { };
-
-        /// <summary>
-        /// Triggered when an EmoteConfig file have been loaded
-        /// </summary>
-        public event Action<UMI3DEmotesConfigDto> EmotesLoadedEvent;
-        public void OnEmoteConfigLoaded(UMI3DEmotesConfigDto dto) => EmotesLoadedEvent?.Invoke(dto);
-
-        /// <summary>
-        /// Triggered when an emote changed on availability
-        /// </summary>
-        public event Action<UMI3DEmoteDto> EmoteUpdatedEvent;
-        public void OnEmoteUpdated(UMI3DEmoteDto dto) => EmoteUpdatedEvent?.Invoke(dto);
-
-        /// <summary>
-        /// Emote configuration on the server, with al available emotes for the user.
-        /// </summary>
-        protected UMI3DEmotesConfigDto emoteConfig;
-
         ///// <inheritdoc/>
         //protected override IEnumerator DispatchTracking()
         //{

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/UMI3DCollaborationLoadingHandler.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/UMI3DCollaborationLoadingHandler.cs
@@ -54,7 +54,7 @@ namespace umi3d.cdk.collaboration
             if (areEmotesSupported)
             {
                 emoteService = EmoteManager.Instance;
-                emoteService.Initialize(defaultEmoteIcon);
+                emoteService.DefaultIcon = defaultEmoteIcon;
             }
 
             base.Awake();

--- a/UMI3D-SDK/ProjectSettings/EditorBuildSettings.asset
+++ b/UMI3D-SDK/ProjectSettings/EditorBuildSettings.asset
@@ -11,4 +11,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Tests/PlayMode_Tests/TestScenes/TESTSCENE_Bindings.unity
     guid: 28baf46180f581047a8552c736bbb5ab
+  - enabled: 1
+    path: Assets/Tests/PlayMode_Tests/TestScenes/TESTSCENE_Empty.unity
+    guid: 5e8cf43c8408df14fb8786a068d215a1
   m_configObjects: {}

--- a/UMI3D-SDK/UserSettings/EditorUserSettings.asset
+++ b/UMI3D-SDK/UserSettings/EditorUserSettings.asset
@@ -21,7 +21,13 @@ EditorUserSettings:
       value: 5a5757560101590a5d0c0e24427b5d44434e4c7a7b7a23677f2b4565b7b5353a
       flags: 0
     RecentlyUsedSceneGuid-5:
+      value: 055402525d560b5854590f2440225944464f1d727d2b23607c284e61e7b86c68
+      flags: 0
+    RecentlyUsedSceneGuid-6:
       value: 5109560703015f0a555e0a7748720f444116407f797a25677e7f1f31e0b5353a
+      flags: 0
+    RecentlyUsedSceneGuid-7:
+      value: 56540c0503015a58555a5c7a14250e441015407d747e27607b711961b3b53569
       flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650


### PR DESCRIPTION
EmoteManager service is now always instanciated when an emoteconfigDto is received. But it's up to the brower to decide what to do with the loaded emotes.