### PR TITLE
Changed audioSource binding in AudioBridger

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/UMI3DAudioBridger.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/UMI3DAudioBridger.cs
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 using System.Collections;
+using umi3d.common.userCapture;
+using umi3d.edk.userCapture;
 using UnityEngine;
 
 namespace umi3d.edk.collaboration
@@ -57,29 +59,49 @@ namespace umi3d.edk.collaboration
 
         private IEnumerator SetAudioSource(UMI3DCollaborationUser user)
         {
-            var wait = new WaitForFixedUpdate();
-            while (user.Avatar == null)
-                yield return wait;
-            user.audioPlayer = user.Avatar.gameObject.GetComponent<UMI3DAudioPlayer>();
-            if (user.audioPlayer == null)
+            while (user.CurrentTrackingFrame == null)
+                yield return new WaitForFixedUpdate();
+
+            Transaction tr = new Transaction() { reliable = true };
+
+            // Look for audio source
+            UMI3DNode audioSourceNode;
+            if (user.audioPlayer == null) // create one if does not exist
             {
-                user.audioPlayer = user.Avatar.gameObject.AddComponent<UMI3DAudioPlayer>();
+                GameObject go = new GameObject($"AudioSource_user_{user.Id()}");
+                audioSourceNode = go.AddComponent<UMI3DNode>();
+
+                user.audioPlayer = audioSourceNode.gameObject.AddComponent<UMI3DAudioPlayer>();
                 user.audioPlayer.ObjectSpacialBlend.SetValue(Spacialized ? 1 : 0);
-                user.audioPlayer.ObjectNode.SetValue(user.Avatar);
-                var tr = new Transaction() { reliable = true };
+                user.audioPlayer.ObjectNode.SetValue(audioSourceNode);
+
+                tr.AddIfNotNull(audioSourceNode.GetLoadEntity());
                 tr.AddIfNotNull(user.audioPlayer.GetLoadEntity());
-                UMI3DServer.Dispatch(tr);
             }
-            if (user.audioPlayer.ObjectNode.GetValue() == null)
+            else
             {
-                SetEntityProperty op = user.audioPlayer.ObjectNode.SetValue(user.Avatar);
-                if (op != null)
+                audioSourceNode = user.audioPlayer.ObjectNode.GetValue();
+                if (audioSourceNode == null)
                 {
-                    var tr = new Transaction() { reliable = true };
-                    tr.AddIfNotNull(op);
-                    UMI3DServer.Dispatch(tr);
-                }
+                    GameObject go = new GameObject($"AudioSource_user_{user.Id()}");
+                    audioSourceNode = go.AddComponent<UMI3DNode>();
+                    tr.AddIfNotNull(user.audioPlayer.ObjectNode.SetValue(audioSourceNode));
+                }    
             }
+
+            // Binding
+            var binding = new UMI3DBinding()
+            {
+                syncPosition = true,
+                syncRotation = true,
+                boneType = BoneType.Head,
+                priotity = 100,
+                node = audioSourceNode
+            };
+
+            tr.AddIfNotNull(BindingManager.Instance.AddBinding(user, binding));
+            UMI3DServer.Dispatch(tr);
+            
             UMI3DServer.Instance.NotifyUserChanged(user);
         }
 


### PR DESCRIPTION
To fit the deleletion of avatar nodes, audioSources are now bound to user heads