### PR TITLE
Simplified extrapolator API

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/TrackingKalmanFilters/UMI3DCollaborativeUserAvatar.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/TrackingKalmanFilters/UMI3DCollaborativeUserAvatar.cs
@@ -70,18 +70,18 @@ namespace umi3d.cdk.collaboration
         private void LateUpdate()
         {
             if (nodePositionExtrapolator != null)
-                this.transform.localPosition = nodePositionExtrapolator.ExtrapolateState();
+                this.transform.localPosition = nodePositionExtrapolator.Extrapolate();
 
             if (nodeRotationExtrapolator != null)
-                this.transform.localRotation = nodeRotationExtrapolator.ExtrapolateState();
+                this.transform.localRotation = nodeRotationExtrapolator.Extrapolate();
 
             if (skeleton == null)
                 return;
 
             if (skeletonHeightExtrapolator != null)
             {
-                var e = skeletonHeightExtrapolator.ExtrapolateState();
-                skeleton.transform.localPosition = new Vector3(0, skeletonHeightExtrapolator.ExtrapolateState(), 0);
+                var e = skeletonHeightExtrapolator.Extrapolate();
+                skeleton.transform.localPosition = new Vector3(0, skeletonHeightExtrapolator.Extrapolate(), 0);
             }
 
             if (ForceDisablingBinding)
@@ -103,7 +103,7 @@ namespace umi3d.cdk.collaboration
                 {
                     boneTransform = viewpointObject;
                     if (boneRotationFilters[boneType] != null)
-                        boneTransform.parent.localRotation = boneRotationFilters[boneType].ExtrapolateState();
+                        boneTransform.parent.localRotation = boneRotationFilters[boneType].Extrapolate();
                 }
                 else
                 {
@@ -113,7 +113,7 @@ namespace umi3d.cdk.collaboration
                         boneTransform = userAnimator.GetBoneTransform(boneType.ConvertToBoneType().GetValueOrDefault());
 
                     if (boneRotationFilters[boneType] != null)
-                        boneTransform.localRotation = boneRotationFilters[boneType].ExtrapolateState();
+                        boneTransform.localRotation = boneRotationFilters[boneType].Extrapolate();
                 }
 
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Loaders/UMI3DEnvironmentLoader.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Loaders/UMI3DEnvironmentLoader.cs
@@ -1016,7 +1016,7 @@ namespace umi3d.cdk
 
 
 
-        private readonly Dictionary<ulong, Dictionary<ulong, AbstractExtrapolator>> entityFilters = new Dictionary<ulong, Dictionary<ulong, AbstractExtrapolator>>();
+        private readonly Dictionary<ulong, Dictionary<ulong, IExtrapolator>> entityFilters = new Dictionary<ulong, Dictionary<ulong, IExtrapolator>>();
 
         private void Update()
         {
@@ -1025,15 +1025,15 @@ namespace umi3d.cdk
                 foreach (ulong property in Instance.entityFilters[entityId].Keys)
                 {
                     UMI3DEntityInstance node = UMI3DEnvironmentLoader.GetEntity(entityId);
-                    AbstractExtrapolator extrapolator = Instance.entityFilters[entityId][property];
+                    IExtrapolator extrapolator = Instance.entityFilters[entityId][property];
 
-                    extrapolator.UpdateRegressedValue();
+                    extrapolator.ComputeExtrapolatedValue();
 
                     var entityPropertyDto = new SetEntityPropertyDto()
                     {
-                        entityId = extrapolator.entityId,
-                        property = extrapolator.property,
-                        value = extrapolator.GetRegressedValue().ToSerializable()
+                        entityId = entityId,
+                        property = property,
+                        value = extrapolator.ExtrapolatedValue.ToSerializable()
                     };
 
                     SimulatedSetEntity(new SetUMI3DPropertyData(entityPropertyDto, node));
@@ -1074,28 +1074,16 @@ namespace umi3d.cdk
         {
             if (!entityFilters.ContainsKey(entityId))
             {
-                entityFilters.Add(entityId, new Dictionary<ulong, AbstractExtrapolator>());
+                entityFilters.Add(entityId, new Dictionary<ulong, IExtrapolator>());
             }
 
             if (!entityFilters[entityId].ContainsKey(propertyKey))
             {
-                AbstractExtrapolator newExtrapolator;
+                IExtrapolator newExtrapolator;
                 if (propertyKey == UMI3DPropertyKeys.Rotation)
-                {
-                    newExtrapolator = new QuaternionLinearDelayedExtrapolator()
-                    {
-                        entityId = entityId,
-                        property = propertyKey
-                    };
-                }
+                    newExtrapolator = new QuaternionLinearDelayedExtrapolator();
                 else
-                {
-                    newExtrapolator = new Vector3LinearDelayedExtrapolator()
-                    {
-                        entityId = entityId,
-                        property = propertyKey
-                    };
-                }
+                    newExtrapolator = new Vector3LinearDelayedExtrapolator();
 
                 entityFilters[entityId].Add(propertyKey, newExtrapolator);
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Utils/Extrapolation/KalmanExtrapolator.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Utils/Extrapolation/KalmanExtrapolator.cs
@@ -27,7 +27,7 @@ namespace umi3d.cdk.utils.extrapolation.kalman
         /// Is the kalman-filter based object able to make predictions?
         /// </summary>
         /// <returns></returns>
-        bool IsInited();
+        bool IsInited { get; }
 
         /// <summary>
         /// Add a measure to the kalman-filter based object and correct the prediction onto an estimation.

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Utils/Extrapolation/LinearDelayedExtrapolator.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Utils/Extrapolation/LinearDelayedExtrapolator.cs
@@ -58,29 +58,26 @@ namespace umi3d.cdk.utils.extrapolation
         /// <param name="time"></param>
         public void AddMeasure(T measure, float time)
         {
-            if (time < lastMessageTime)
+            if (time < lastUpdateTime)
                 return;
 
-            if (IsInited())
-                lastEstimation = ExtrapolateState();
+            if (IsInited)
+                lastEstimation = Extrapolate();
             else
                 lastEstimation = measure;
 
             secondLastMeasure = lastMeasure;
             lastMeasure = measure;
 
-            if (lastMessageTime > 0)
-                updateFrequency = 1 / (time - lastMessageTime);
+            if (lastUpdateTime > 0)
+                updateFrequency = 1 / (time - lastUpdateTime);
 
-            secondLastMessageTime = lastMessageTime;
-            lastMessageTime = time;
+            secondLastMessageTime = lastUpdateTime;
+            lastUpdateTime = time;
         }
 
         /// <inheritdoc/>
-        public override bool IsInited()
-        {
-            return (lastMessageTime != 0) && (secondLastMessageTime != 0);
-        }
+        public override bool IsInited => (lastUpdateTime != 0) && (secondLastMessageTime != 0);
     }
 
     /// <summary>
@@ -90,10 +87,10 @@ namespace umi3d.cdk.utils.extrapolation
     public class FloatLinearDelayedExtrapolator : AbstractLinearDelayedExtrapolator<float>
     {
         /// <inheritdoc/>
-        public override float ExtrapolateState()
+        public override float Extrapolate()
         {
-            var t = (Time.time - lastMessageTime) * updateFrequency;
-            if (t > 0 && IsInited())
+            var t = (Time.time - lastUpdateTime) * updateFrequency;
+            if (t > 0 && IsInited)
                 return t < 1 ? lastEstimation + (lastMeasure - lastEstimation) * t : lastMeasure; //clamped lerp
             else
                 return lastEstimation;
@@ -107,10 +104,10 @@ namespace umi3d.cdk.utils.extrapolation
     public class Vector3LinearDelayedExtrapolator : AbstractLinearDelayedExtrapolator<Vector3>
     {
         /// <inheritdoc/>
-        public override Vector3 ExtrapolateState()
+        public override Vector3 Extrapolate()
         {
-            var t = (Time.time - lastMessageTime) * updateFrequency;
-            if (t > 0 && IsInited())
+            var t = (Time.time - lastUpdateTime) * updateFrequency;
+            if (t > 0 && IsInited)
                 return Vector3.Lerp(lastEstimation, lastMeasure, t);
             else
                 return lastEstimation;
@@ -124,10 +121,10 @@ namespace umi3d.cdk.utils.extrapolation
     public class QuaternionLinearDelayedExtrapolator : AbstractLinearDelayedExtrapolator<Quaternion>
     {
         /// <inheritdoc/>
-        public override Quaternion ExtrapolateState()
+        public override Quaternion Extrapolate()
         {
-            var t = (Time.time - lastMessageTime) * updateFrequency;
-            if (t > 0 && IsInited())
+            var t = (Time.time - lastUpdateTime) * updateFrequency;
+            if (t > 0 && IsInited)
                 return Quaternion.Lerp(lastEstimation, lastMeasure, t);
             else
                 return lastEstimation;

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Utils/Extrapolation/LinearExtrapolator.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Utils/Extrapolation/LinearExtrapolator.cs
@@ -63,7 +63,7 @@ namespace umi3d.cdk.utils.extrapolation
         /// <param name="time"></param>
         public virtual void AddMeasure(T measure, float time)
         {
-            if (time <= lastMessageTime)
+            if (time <= lastUpdateTime)
                 return;
 
             if (!isInited) //requires two measures to be inited
@@ -72,12 +72,12 @@ namespace umi3d.cdk.utils.extrapolation
                 isInited = true;
             }
 
-            lastEstimation = ExtrapolateState();
-            updateFrequency = 1f / (time - lastMessageTime);
+            lastEstimation = Extrapolate();
+            updateFrequency = 1f / (time - lastUpdateTime);
 
             Predict(measure, time);
             lastMeasure = measure;
-            lastMessageTime = time;
+            lastUpdateTime = time;
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace umi3d.cdk.utils.extrapolation
         public abstract void Predict(T measure, float time);
 
         /// <inheritdoc/>
-        public override bool IsInited() => isInited;
+        public override bool IsInited => isInited;
     }
 
     /// <summary>
@@ -110,15 +110,15 @@ namespace umi3d.cdk.utils.extrapolation
         public override void Predict(float measure, float time)
         {
             previous_prediction = prediction;
-            var t = 1f + (time - lastMessageTime) * updateFrequency;
+            var t = 1f + (time - lastUpdateTime) * updateFrequency;
             t = t > 0 ? t : 0;
             prediction = measure + (measure - lastMeasure) * t;
         }
 
         /// <inheritdoc/>
-        public override float ExtrapolateState()
+        public override float Extrapolate()
         {
-            var t = (Time.time - lastMessageTime) * updateFrequency;
+            var t = (Time.time - lastUpdateTime) * updateFrequency;
             if (t > 0 && isInited && !lastEstimation.Equals(prediction))
                 return lastEstimation + (prediction - lastEstimation) * t;
             else
@@ -136,15 +136,15 @@ namespace umi3d.cdk.utils.extrapolation
         public override void Predict(Vector3 measure, float time)
         {
             previous_prediction = prediction;
-            var t = 1f + (time - lastMessageTime) * updateFrequency;
+            var t = 1f + (time - lastUpdateTime) * updateFrequency;
             t = t > 0 ? t : 0;
             prediction = Vector3.LerpUnclamped(measure, measure + (measure - lastMeasure), t);
         }
 
         /// <inheritdoc/>
-        public override Vector3 ExtrapolateState()
+        public override Vector3 Extrapolate()
         {
-            var t = (Time.time - lastMessageTime) * updateFrequency;
+            var t = (Time.time - lastUpdateTime) * updateFrequency;
             if (t > 0 && isInited && !lastEstimation.Equals(prediction))
                 return Vector3.Lerp(lastEstimation, prediction, t);
             else
@@ -162,15 +162,15 @@ namespace umi3d.cdk.utils.extrapolation
         public override void Predict(Quaternion measure, float time)
         {
             previous_prediction = prediction;
-            var t = 1f + (time - lastMessageTime) * updateFrequency;
+            var t = 1f + (time - lastUpdateTime) * updateFrequency;
             t = t > 0 ? t : 0;
             prediction = Quaternion.LerpUnclamped(measure, measure * (measure * Quaternion.Inverse(lastMeasure)), t);
         }
 
         /// <inheritdoc/>
-        public override Quaternion ExtrapolateState()
+        public override Quaternion Extrapolate()
         {
-            var t = (Time.time - lastMessageTime) * updateFrequency;
+            var t = (Time.time - lastUpdateTime) * updateFrequency;
             if (t > 0 && isInited && !lastEstimation.Equals(prediction))
                 return Quaternion.Lerp(lastEstimation, prediction, t);
             else


### PR DESCRIPTION
Reduced the number of exposed members
Usage of ComputeExtrapolatedValue and ExtrapolateState should be clearer
Switched AbstractExtrapolator to interface
Renamed fields
Moved from IsInited method to IsInited property
Removed useless fields
Renamed Extrapolate method