### PR TITLE
Disabled emote request dispatch

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/UMI3DClientUserTracking.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/UMI3DClientUserTracking.cs
@@ -230,12 +230,14 @@ namespace umi3d.cdk.userCapture
             EmotesLoadedEvent.AddListener((UMI3DEmotesConfigDto dto) => { emoteConfig = dto; });
             EmotePlayedSelfEvent.AddListener(delegate
             {
-                IgnoreBones = true;
+                //todo: re-enable emote dispatch when emote animations are supported on VR and RPM
+                //IgnoreBones = true;
                 IsEmotePlaying = true;
             });
             EmoteEndedSelfEvent.AddListener(delegate
             {
-                IgnoreBones = false;
+                //todo: re-enable emote dispatch when emote animations are supported on VR and RPM
+                //IgnoreBones = false;
                 IsEmotePlaying = false;
             });
         }

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/UserCapture/Runtime/Tracking/UMI3DEmbodimentManager.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/UserCapture/Runtime/Tracking/UMI3DEmbodimentManager.cs
@@ -246,6 +246,7 @@ namespace umi3d.edk.userCapture
             var targetUsers = new HashSet<UMI3DUser>(UMI3DServer.Instance.Users());
             EmoteTriggered?.Invoke((emoteId, user, trigger));
             targetUsers.Remove(user);
+            return; //todo: re-enable emote dispatch when emote animations are supported on VR and RPM
             var req = new EmoteDispatchRequest()
             {
                 sendingUserId = user.Id(),


### PR DESCRIPTION
Emotes are still not supported on VR but request are required for external modules. This commit should be reverted once a solution to support emotes on VR is found.