### PR TITLE
Make UpdateHelper safer

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/Dependencies/Runtime/Inetum-Unity-Utils/Tool/Editor/UpdateHelper.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Dependencies/Runtime/Inetum-Unity-Utils/Tool/Editor/UpdateHelper.cs
@@ -17,7 +17,6 @@ limitations under the License.
 #if UNITY_EDITOR
 namespace inetum.unityUtils
 {
-
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -57,7 +56,7 @@ namespace inetum.unityUtils
         public static void Open(bool sourceIsA, string name1, string name2, string path1, string path2, Action<(bool, List<string>)> callback, List<string> folders = null)
         {
             // Get existing open window or if none, make a new one :
-            SubUpdateHelper window = (SubUpdateHelper)EditorWindow.GetWindow(typeof(SubUpdateHelper),false, "Folders");
+            SubUpdateHelper window = (SubUpdateHelper)EditorWindow.GetWindow(typeof(SubUpdateHelper), false, "Folders");
             window.Init(sourceIsA, name1, name2, path1, path2, folders, callback);
             window.Show();
         }
@@ -224,7 +223,7 @@ namespace inetum.unityUtils
 
         void Found(folder folder)
         {
-            var d = Directory.GetDirectories(folder.path, "*", SearchOption.TopDirectoryOnly);
+            var d = Directory.GetDirectories(folder.path, "*", System.IO.SearchOption.TopDirectoryOnly);
             foreach (var p in d)
             {
                 var f = new folder(p);
@@ -248,5 +247,197 @@ namespace inetum.unityUtils
         }
 
     }
+
+
+    public class ConfirmWindow : EditorWindow
+    {
+        bool inited = false;
+
+        string warningMessage;
+
+        bool shouldDeletePermanent;
+
+        GUIStyle style = new GUIStyle();
+
+        public class DeletionData
+        {
+            public string fromPath;
+            public string toPath;
+
+            public string fromName;
+            public string toName;
+
+            public List<string> modifiedFolders;
+
+            public bool isMovingFromInternal;
+        }
+
+        DeletionData data;
+
+        public void Init(bool isAReferenceFolder, string name1, string name2, string path1, string path2, List<string> folders)
+        {
+            style.richText = true;
+            style.normal.textColor = Color.white;
+
+            data = new DeletionData()
+            {
+                fromPath = path1,
+                toPath = path2,
+
+                fromName = name1,
+                toName = name2,
+
+                modifiedFolders = folders,
+
+                isMovingFromInternal = isAReferenceFolder
+            };
+
+
+            warningMessage = $"Are you sure your want to use the files from <b>{data.fromName}</b> replacing the one from <b>{data.toName}</b>?";
+            inited = true;
+        }
+
+
+        void OnGUI()
+        {
+            if (!inited)
+                Close();
+
+            EditorGUILayout.LabelField($"<b>{data.fromName} -> {data.toName}</b>", style);
+
+            EditorGUILayout.LabelField(warningMessage, style);
+
+            EditorGUILayout.LabelField("This will override the following folders and all their content:");
+
+            EditorGUILayout.BeginScrollView(Vector2.zero);
+            foreach (var folder in data.modifiedFolders)
+            {
+                EditorGUILayout.LabelField("- " + folder[folder.IndexOf("Assets/")..].Replace("\\", "/"));
+            }
+            EditorGUILayout.EndScrollView();
+
+            shouldDeletePermanent = EditorGUILayout.ToggleLeft("Delete existing folders permanently", shouldDeletePermanent);
+
+            EditorGUILayout.BeginHorizontal();
+            if (GUILayout.Button("Cancel"))
+            {
+                Close();
+                shouldDeletePermanent = false;
+                inited = false;
+            }
+
+            if (GUILayout.Button("Yes"))
+            {
+                UpdateHelperCopier.Copy(data.isMovingFromInternal, data.fromPath, data.toPath, data.modifiedFolders, shouldDeletePermanent);
+                Close();
+                shouldDeletePermanent = false;
+                inited = false;
+            }
+            EditorGUILayout.EndHorizontal();
+        }
+
+        public static void Open(bool isMovingFromReferenceFolder, string name1, string name2, string path1, string path2, List<string> folders = null)
+        {
+            // Get existing open window or if none, make a new one :
+            var window = (ConfirmWindow)GetWindow(typeof(ConfirmWindow), false, "Confirm copy");
+            window.Init(isMovingFromReferenceFolder, name1, name2, path1, path2, folders);
+            window.Show();
+        }
+    }
+
+
+    public static class UpdateHelperCopier
+    {
+        public static void Copy(bool isMovingFromReferenceFolder, string pathFrom, string pathTo, List<string> modifiedFolders, bool shouldPermanentDelete)
+        {
+            if (modifiedFolders == null || modifiedFolders.Count == 0)
+                return;
+
+            if (!Directory.Exists(pathTo))
+                Directory.CreateDirectory(pathTo);
+
+            var movePathsInfos = modifiedFolders
+                .Select(path => isMovingFromReferenceFolder ? path[pathFrom.Length..] : path[pathTo.Length..])
+                .Select(relativePath =>
+                {
+                    return (originPath: Path.Combine(pathFrom, relativePath), targetPath: Path.Combine(pathTo, relativePath));
+                }).ToList();
+
+
+            var directoriesToDestroy = movePathsInfos
+                                            .Where(movePaths => Directory.Exists(movePaths.targetPath))
+                                            .Select(movePaths => movePaths.targetPath).ToList();
+
+            if (directoriesToDestroy.Count > 0 && shouldPermanentDelete)
+                foreach (var path in directoriesToDestroy)
+                    Directory.Delete(path, true);
+            else
+                SafeDelete(directoriesToDestroy, isMovingFromReferenceFolder);
+                
+
+            foreach (var c in movePathsInfos)
+                CopyFolder(isMovingFromReferenceFolder, c.originPath, c.targetPath, shouldPermanentDelete);
+        }
+
+        public static void CopyFolder(bool isMovingFromReferenceFolder, string pathFrom, string pathTo, bool shouldPermanentDelete)
+        {
+            Directory.CreateDirectory(pathTo);
+
+            //Now Create all of the directories
+            foreach (string dirPath in Directory.GetDirectories(pathFrom, "*", System.IO.SearchOption.AllDirectories))
+            {
+                Directory.CreateDirectory(dirPath.Replace(pathFrom, pathTo));
+            }
+
+            //Copy all the files & Replaces any files with the same name
+            foreach (string newPath in Directory.GetFiles(pathFrom, "*.*", System.IO.SearchOption.AllDirectories))
+            {
+                File.Copy(newPath, newPath.Replace(pathFrom, pathTo), true);
+            }
+
+        }
+
+        public static void SafeDelete(string path, bool isAssetExternal)
+        {
+            if (isAssetExternal) //in this case the pathTo is external to the project
+            {
+                string folderName = path[(path.LastIndexOf("/")+1)..];
+                System.IO.Directory.Move(path, $"Assets/__TMP_UPDATE_HELPER_SAVE_{folderName}"); // import in project to use API
+                AssetDatabase.Refresh();
+                AssetDatabase.MoveAssetToTrash($"Assets/__TMP_UPDATE_HELPER_SAVE_{folderName}");
+            }
+            else
+            { //in this case the pathTo is internal to the project
+                AssetDatabase.MoveAssetToTrash(path[path.IndexOf("Assets/")..]);
+            }
+        }
+
+        /// <summary>
+        /// Optimized for several deletions
+        /// </summary>
+        /// <param name="paths"></param>
+        /// <param name="areAssetExternals"></param>
+        public static void SafeDelete(List<string> paths, bool areAssetExternals)
+        {
+            if (areAssetExternals) //in this case the pathTo is external to the project
+            {
+                var tmpPaths = paths.Select(path =>
+                {
+                    string folderName = path[(path.LastIndexOf("/") + 1)..];
+                    string tmpPath = $"Assets/__TMP_UPDATE_HELPER_SAVE_{folderName}";
+                    System.IO.Directory.Move(path, tmpPath); // import in project to use API
+                    return tmpPath;
+                }).ToArray();
+                
+                AssetDatabase.Refresh();
+                AssetDatabase.MoveAssetsToTrash(tmpPaths, new List<string>());
+            }
+            else
+            { //in this case the pathTo is internal to the project
+                AssetDatabase.MoveAssetsToTrash(paths.Select(path=>path[path.IndexOf("Assets/")..]).ToArray(), new List<string>());
+            }
+        }
+    }
+
 }
 #endif


### PR DESCRIPTION
- Moved copying logic to a static class
- Added a new window to confirm override
- Changed deletion API to make it target recycle bin if possible, by default
- Added a toggle to avoid previous behaviour
- Changed buttons label for more readability