### PR TITLE
Change binding formula

### DIFF
--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/BoneBinding_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/BoneBinding_Test.cs
@@ -97,6 +97,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             BoneBinding binding = new(dto, go.transform, skeletonBoneMock.Object);
 
+            var parentPreviousPosition = parentGo.transform.position;
             var previousPosition = go.transform.position;
             var previousRotation = go.transform.rotation;
             var previousScale = go.transform.localScale;
@@ -106,7 +107,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             // THEN
             Assert.IsTrue(succes);
-            Assert.AreEqual(parentGo.transform.position + offSetPosition, go.transform.position);
+            Assert.AreEqual(parentGo.transform.position - parentPreviousPosition, go.transform.position - previousPosition - offSetPosition);
             Assert.AreEqual(previousRotation, go.transform.rotation);
             Assert.AreEqual(previousScale, go.transform.localScale);
         }
@@ -134,11 +135,14 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             BoneBinding binding = new(dto, go.transform, skeletonBoneMock.Object);
 
+            var parentPreviousPosition = parentGo.transform.position;
             var previousPosition = go.transform.position;
             var previousRotation = go.transform.rotation;
             var previousScale = go.transform.localScale;
 
             int numberOfFrames = 10;
+
+            binding.Apply(out _);
 
             for (int i = 0; i < numberOfFrames; i++)
             {
@@ -154,7 +158,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
                 // THEN
                 Assert.IsTrue(succes);
-                Assert.AreEqual(parentGo.transform.position + offSetPosition, go.transform.position);
+                Assert.IsTrue((parentGo.transform.position - parentPreviousPosition) == (go.transform.position - previousPosition - offSetPosition));
                 Assert.AreEqual(previousRotation, go.transform.rotation);
                 Assert.AreEqual(previousScale, go.transform.localScale);
 
@@ -199,7 +203,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
             // THEN
             Assert.IsTrue(success);
             Assert.AreEqual(previousPosition, go.transform.position);
-            Assert.IsTrue(parentGo.transform.rotation * offsetRotation == go.transform.rotation);
+            Assert.IsTrue(parentGo.transform.rotation * offsetRotation * previousRotation == go.transform.rotation);
             Assert.AreEqual(previousScale, go.transform.localScale);
         }
 
@@ -246,7 +250,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
                 // THEN
                 Assert.IsTrue(success);
                 Assert.AreEqual(previousPosition, go.transform.position);
-                Assert.IsTrue(parentGo.transform.rotation * offsetRotation == go.transform.rotation);
+                Assert.IsTrue(parentGo.transform.rotation * offsetRotation * previousRotation == go.transform.rotation);
                 Assert.AreEqual(previousScale, go.transform.localScale);
 
                 yield return null;

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/RigBoneBinding_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/RigBoneBinding_Test.cs
@@ -105,6 +105,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             RigBoneBinding binding = new(dto, rigGo.transform, skeletonBoneMock.Object);
 
+            var parentPreviousPosition = parentGo.transform.position;
             var previousPosition = rigGo.transform.position;
             var previousRotation = rigGo.transform.rotation;
             var previousScale = rigGo.transform.localScale;
@@ -114,7 +115,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             // THEN
             Assert.IsTrue(succes);
-            Assert.IsTrue(parentGo.transform.position + offSetPosition == rigGo.transform.position);
+            Assert.IsTrue(parentGo.transform.position - parentPreviousPosition == rigGo.transform.position - previousPosition - offSetPosition);
             Assert.IsTrue(previousRotation == rigGo.transform.rotation);
             Assert.IsTrue(previousScale == rigGo.transform.localScale);
         }
@@ -142,11 +143,14 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             RigBoneBinding binding = new(dto, rigGo.transform, skeletonBoneMock.Object);
 
+            var parentPreviousPosition = parentGo.transform.position;
             var previousPosition = rigGo.transform.position;
             var previousRotation = rigGo.transform.rotation;
             var previousScale = rigGo.transform.localScale;
 
             int numberOfFrames = 10;
+
+            binding.Apply(out _);
 
             for (int i = 0; i < numberOfFrames; i++)
             {
@@ -162,7 +166,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
                 // THEN
                 Assert.IsTrue(succes);
-                Assert.IsTrue(parentGo.transform.position + offSetPosition == rigGo.transform.position);
+                Assert.IsTrue((parentGo.transform.position - parentPreviousPosition) == (rigGo.transform.position - previousPosition - offSetPosition));
                 Assert.IsTrue(previousRotation == rigGo.transform.rotation);
                 Assert.IsTrue(previousScale == rigGo.transform.localScale);
 
@@ -207,7 +211,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
             // THEN
             Assert.IsTrue(success);
             Assert.IsTrue(previousPosition == rigGo.transform.position);
-            Assert.IsTrue(parentGo.transform.rotation * offsetRotation == rigGo.transform.rotation);
+            Assert.IsTrue(parentGo.transform.rotation * offsetRotation * previousRotation == rigGo.transform.rotation);
             Assert.IsTrue(previousScale == rigGo.transform.localScale);
         }
 
@@ -254,7 +258,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
                 // THEN
                 Assert.IsTrue(success);
                 Assert.IsTrue(previousPosition == rigGo.transform.position);
-                Assert.IsTrue(parentGo.transform.rotation * offsetRotation == rigGo.transform.rotation);
+                Assert.IsTrue(parentGo.transform.rotation * offsetRotation * previousRotation == rigGo.transform.rotation);
                 Assert.IsTrue(previousScale == rigGo.transform.localScale);
 
                 yield return null;

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/AbstractSimpleBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/AbstractSimpleBinding.cs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 using umi3d.common.dto.binding;
+
 using UnityEngine;
 
 namespace umi3d.cdk.binding
@@ -65,8 +66,13 @@ namespace umi3d.cdk.binding
 
         #endregion DTO access
 
+        private bool isOriginalPositionRegistered;
+        private Vector3 originalPositionOffset;
+        private Quaternion originalRotationOffset;
+
         public AbstractSimpleBinding(AbstractSimpleBindingDataDto dto, Transform boundTransform) : base(boundTransform, dto)
         {
+            originalRotationOffset = boundTransform.rotation;
         }
 
         /// <summary>
@@ -77,17 +83,22 @@ namespace umi3d.cdk.binding
         {
             if (SyncPosition && SyncRotation)
             {
-                Quaternion rotation = parentTransform.rotation * OffSetRotation;
+                Quaternion rotation = parentTransform.rotation * OffSetRotation * originalRotationOffset;
                 Vector3 position = parentTransform.position + AnchorPosition + rotation * (OffSetPosition - AnchorPosition);
                 boundTransform.SetPositionAndRotation(position, rotation);
             }
             else if (SyncPosition)
             {
-                boundTransform.position = parentTransform.position + OffSetPosition;
+                if (!isOriginalPositionRegistered)
+                {
+                    isOriginalPositionRegistered = true;
+                    originalPositionOffset = boundTransform.position - parentTransform.position;
+                }
+                boundTransform.position = parentTransform.position + originalPositionOffset + OffSetPosition;
             }
             else if (SyncRotation)
             {
-                boundTransform.rotation = parentTransform.rotation * OffSetRotation;
+                boundTransform.rotation = parentTransform.rotation * OffSetRotation * originalRotationOffset;
             }
             if (SyncScale)
                 boundTransform.localScale = Vector3.Scale(parentTransform.scale, OffSetScale);


### PR DESCRIPTION
Include by default the previous rotation or position of the object. necessary to load avatars with default rotations without specifying them in EDK.