### PR TITLE
Rollback binding formula for SyncPosition only

### DIFF
--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Core/Binding/NodeBinding_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Core/Binding/NodeBinding_Test.cs
@@ -174,7 +174,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
             // THEN
             Assert.IsTrue(success);
             Assert.AreEqual(previousPosition, go.transform.position);
-            Assert.IsTrue(parentGo.transform.rotation * offsetRotation == go.transform.rotation);
+            Assert.IsTrue(parentGo.transform.rotation * offsetRotation * previousRotation == go.transform.rotation);
             Assert.AreEqual(previousScale, go.transform.localScale);
         }
 
@@ -214,7 +214,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
                 // THEN
                 Assert.IsTrue(success);
                 Assert.AreEqual(previousPosition, go.transform.position);
-                Assert.IsTrue(parentGo.transform.rotation * offsetRotation == go.transform.rotation);
+                Assert.IsTrue(parentGo.transform.rotation * offsetRotation * previousRotation == go.transform.rotation);
                 Assert.AreEqual(previousScale, go.transform.localScale);
 
                 yield return null;

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/BoneBinding_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/BoneBinding_Test.cs
@@ -97,7 +97,6 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             BoneBinding binding = new(dto, go.transform, skeletonBoneMock.Object);
 
-            var parentPreviousPosition = parentGo.transform.position;
             var previousPosition = go.transform.position;
             var previousRotation = go.transform.rotation;
             var previousScale = go.transform.localScale;
@@ -107,7 +106,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             // THEN
             Assert.IsTrue(succes);
-            Assert.AreEqual(parentGo.transform.position - parentPreviousPosition, go.transform.position - previousPosition - offSetPosition);
+            Assert.AreEqual(parentGo.transform.position + offSetPosition, go.transform.position);
             Assert.AreEqual(previousRotation, go.transform.rotation);
             Assert.AreEqual(previousScale, go.transform.localScale);
         }
@@ -135,14 +134,11 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             BoneBinding binding = new(dto, go.transform, skeletonBoneMock.Object);
 
-            var parentPreviousPosition = parentGo.transform.position;
             var previousPosition = go.transform.position;
             var previousRotation = go.transform.rotation;
             var previousScale = go.transform.localScale;
 
             int numberOfFrames = 10;
-
-            binding.Apply(out _);
 
             for (int i = 0; i < numberOfFrames; i++)
             {
@@ -158,7 +154,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
                 // THEN
                 Assert.IsTrue(succes);
-                Assert.IsTrue((parentGo.transform.position - parentPreviousPosition) == (go.transform.position - previousPosition - offSetPosition));
+                Assert.AreEqual(parentGo.transform.position + offSetPosition, go.transform.position);
                 Assert.AreEqual(previousRotation, go.transform.rotation);
                 Assert.AreEqual(previousScale, go.transform.localScale);
 

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/RigBoneBinding_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/RigBoneBinding_Test.cs
@@ -105,7 +105,6 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             RigBoneBinding binding = new(dto, rigGo.transform, skeletonBoneMock.Object);
 
-            var parentPreviousPosition = parentGo.transform.position;
             var previousPosition = rigGo.transform.position;
             var previousRotation = rigGo.transform.rotation;
             var previousScale = rigGo.transform.localScale;
@@ -115,7 +114,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             // THEN
             Assert.IsTrue(succes);
-            Assert.IsTrue(parentGo.transform.position - parentPreviousPosition == rigGo.transform.position - previousPosition - offSetPosition);
+            Assert.IsTrue(parentGo.transform.position + offSetPosition == rigGo.transform.position);
             Assert.IsTrue(previousRotation == rigGo.transform.rotation);
             Assert.IsTrue(previousScale == rigGo.transform.localScale);
         }
@@ -143,14 +142,11 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             RigBoneBinding binding = new(dto, rigGo.transform, skeletonBoneMock.Object);
 
-            var parentPreviousPosition = parentGo.transform.position;
             var previousPosition = rigGo.transform.position;
             var previousRotation = rigGo.transform.rotation;
             var previousScale = rigGo.transform.localScale;
 
             int numberOfFrames = 10;
-
-            binding.Apply(out _);
 
             for (int i = 0; i < numberOfFrames; i++)
             {
@@ -166,7 +162,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
                 // THEN
                 Assert.IsTrue(succes);
-                Assert.IsTrue((parentGo.transform.position - parentPreviousPosition) == (rigGo.transform.position - previousPosition - offSetPosition));
+                Assert.IsTrue(parentGo.transform.position + offSetPosition == rigGo.transform.position);
                 Assert.IsTrue(previousRotation == rigGo.transform.rotation);
                 Assert.IsTrue(previousScale == rigGo.transform.localScale);
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/AbstractSimpleBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/AbstractSimpleBinding.cs
@@ -66,8 +66,6 @@ namespace umi3d.cdk.binding
 
         #endregion DTO access
 
-        private bool isOriginalPositionRegistered;
-        private Vector3 originalPositionOffset;
         private Quaternion originalRotationOffset;
 
         public AbstractSimpleBinding(AbstractSimpleBindingDataDto dto, Transform boundTransform) : base(boundTransform, dto)
@@ -89,12 +87,7 @@ namespace umi3d.cdk.binding
             }
             else if (SyncPosition)
             {
-                if (!isOriginalPositionRegistered)
-                {
-                    isOriginalPositionRegistered = true;
-                    originalPositionOffset = boundTransform.position - parentTransform.position;
-                }
-                boundTransform.position = parentTransform.position + originalPositionOffset + OffSetPosition;
+                boundTransform.position = parentTransform.position + OffSetPosition;
             }
             else if (SyncRotation)
             {


### PR DESCRIPTION
Rollback the position binding formula for position synchronisation only that was modified for consistency reason. Reason is that the formula is simpler when the offset is the difference between the parent and the child.