### PR TITLE
Change log level

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/UMI3DAnimatorAnimation.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/UMI3DAnimatorAnimation.cs
@@ -188,11 +188,10 @@ namespace umi3d.cdk
 
             if (animator == null)
             {
-                UMI3DLogger.LogError($"No animator on node {node}", DebugScope.CDK | DebugScope.Animation);
+                UMI3DLogger.LogWarning($"No animator on node {node}. Animation paused.", DebugScope.CDK | DebugScope.Animation);
                 IsPaused = true;
                 return;
             }
-
             animator.Play(dto.stateName, layer: 0, normalizedTime: nTime);
             IsPaused = false;
             trackingAnimationCoroutine ??= coroutineService.AttachCoroutine(TrackEnd());


### PR DESCRIPTION
It is impossible to prevent that an animator could be destroyed, e.g. when a user is leaving. It is the job of the environment to clean the mess. The error should not pop on browsers.

Happened on samples when some user where leaving and the skeleton destruction was applied before the animation node destruction.