### PR TITLE
Clear compute coroutine on Clear

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/UserCapture/CollaborationSkeletonsManager.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/UserCapture/CollaborationSkeletonsManager.cs
@@ -160,7 +160,10 @@ namespace umi3d.cdk.collaboration.userCapture
             }
 
             if (computeCoroutine != null)
+            {
                 routineService.DetachLateRoutine(computeCoroutine);
+                computeCoroutine = null;
+            } 
         }
 
         private void InitSkeletons()


### PR DESCRIPTION
Compute coroutine was not set back to null when the singleton was cleared. Thus never been started again on a new connection.