### PR TITLE
Change null checking for bound transform

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/NodeBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/NodeBinding.cs
@@ -46,7 +46,7 @@ namespace umi3d.cdk.binding
         /// <inheritdoc/>
         public override void Apply(out bool success)
         {
-            if (boundTransform is null || parentNode is null || parentNode.transform == null)
+            if (boundTransform == null || parentNode is null || parentNode.transform == null)
             {
                 if (parentNode is null || parentNode.transform == null)
                     UMI3DLogger.LogError($"Node {NodeBindingDataDto.parentNodeId} is null. It may have been deleted without removing the binding first.", DebugScope.CDK | DebugScope.Core);

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/RigNodeBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/RigNodeBinding.cs
@@ -43,7 +43,7 @@ namespace umi3d.cdk.binding
         /// <inheritdoc/>
         public override void Apply(out bool success)
         {
-            if (boundTransform is null || parentNode is null || parentNode.transform == null || RigName == null)
+            if (boundTransform == null || parentNode is null || parentNode.transform == null || RigName == null)
             {
                 if (parentNode is null || parentNode.transform == null)
                     UMI3DLogger.LogError($"Node {NodeBindingDataDto.parentNodeId} is null. It may have been deleted without removing the binding first.", DebugScope.CDK | DebugScope.Core);

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Binding/Objects/BoneBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Binding/Objects/BoneBinding.cs
@@ -55,7 +55,7 @@ namespace umi3d.cdk.userCapture.binding
         /// <inheritdoc/>
         public override void Apply(out bool success)
         {
-            if (boundTransform is null) // node is destroyed
+            if (boundTransform == null) // node is destroyed
             {
                 UMI3DLogger.LogWarning($"Bound transform is null. It may have been deleted without removing the binding first.", DebugScope.CDK | DebugScope.Core);
                 success = false;

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Binding/Objects/RigBoneBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Binding/Objects/RigBoneBinding.cs
@@ -42,7 +42,7 @@ namespace umi3d.cdk.userCapture.binding
         /// <inheritdoc/>
         public override void Apply(out bool success)
         {
-            if (boundTransform is null) // node is destroyed
+            if (boundTransform == null) // node is destroyed
             {
                 success = false;
                 return;


### PR DESCRIPTION
Unity overrides null checking and this was causing an issue where boundTrasnform was not recognized as null