### PR TITLE
Add UT on skeletons

### DIFF
--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/Skeletons/CollaborativeSkeleton_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/Skeletons/CollaborativeSkeleton_Test.cs
@@ -39,13 +39,13 @@ namespace PlayMode_Tests.Collaboration.UserCapture.CDK
             trackedSusbskeletonGo = new GameObject("tracked subskeleton");
             var camera = trackedSusbskeletonGo.AddComponent<Camera>();
 
-            var trackedSubskeletonMock = new Mock<ITrackedSubskeleton>();
+            trackedSubskeletonMock = new Mock<ITrackedSubskeleton>();
             trackedSubskeletonMock.Setup(x => x.Hips).Returns(trackedSusbskeletonGo.transform);
             trackedSubskeletonMock.Setup(x => x.ViewPoint).Returns(camera);
 
-            var poseSkeletonMock = new Mock<IPoseSubskeleton>();
+            poseSubskeletonMock = new Mock<IPoseSubskeleton>();
 
-            abstractSkeleton.Init(trackedSubskeletonMock.Object, poseSkeletonMock.Object);
+            abstractSkeleton.Init(trackedSubskeletonMock.Object, poseSubskeletonMock.Object);
         }
 
         public override void TearDown()

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/Skeletons/CollaborativeSkeleton_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/Skeletons/CollaborativeSkeleton_Test.cs
@@ -14,17 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using Moq;
 using NUnit.Framework;
 using PlayMode_Tests.UserCapture.Skeletons.CDK;
-using umi3d.cdk.collaboration;
 using umi3d.cdk.collaboration.userCapture;
+using umi3d.cdk.userCapture.pose;
+using umi3d.cdk.userCapture.tracking;
 using UnityEngine;
-using UnityEngine.SceneManagement;
 
 namespace PlayMode_Tests.Collaboration.UserCapture.CDK
 {
     public class CollaborativeSkeleton_Test : AbstractSkeleton_Test
     {
+        protected GameObject trackedSusbskeletonGo;
+
         [SetUp]
         public override void SetUp()
         {
@@ -32,6 +35,24 @@ namespace PlayMode_Tests.Collaboration.UserCapture.CDK
 
             abstractSkeleton = skeletonGo.AddComponent<CollaborativeSkeleton>();
             abstractSkeleton.SkeletonHierarchy = new(null);
+
+            trackedSusbskeletonGo = new GameObject("tracked subskeleton");
+            var camera = trackedSusbskeletonGo.AddComponent<Camera>();
+
+            var trackedSubskeletonMock = new Mock<ITrackedSubskeleton>();
+            trackedSubskeletonMock.Setup(x => x.Hips).Returns(trackedSusbskeletonGo.transform);
+            trackedSubskeletonMock.Setup(x => x.ViewPoint).Returns(camera);
+
+            var poseSkeletonMock = new Mock<IPoseSubskeleton>();
+
+            abstractSkeleton.Init(trackedSubskeletonMock.Object, poseSkeletonMock.Object);
+        }
+
+        public override void TearDown()
+        {
+            base.TearDown();
+
+            Object.Destroy(trackedSusbskeletonGo);
         }
     }
 }

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Skeletons/AbstractSkeleton_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Skeletons/AbstractSkeleton_Test.cs
@@ -21,9 +21,12 @@ using System.Linq;
 using umi3d.cdk;
 using umi3d.cdk.userCapture;
 using umi3d.cdk.userCapture.animation;
+using umi3d.cdk.userCapture.pose;
+using umi3d.cdk.userCapture.tracking;
 using umi3d.common.userCapture;
 using umi3d.common.userCapture.description;
 using umi3d.common.userCapture.pose;
+using umi3d.common.userCapture.tracking;
 using umi3d.common.utils;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -37,6 +40,9 @@ namespace PlayMode_Tests.UserCapture.Skeletons.CDK
         protected AbstractSkeleton abstractSkeleton;
         protected GameObject skeletonGo;
         private Mock<IUnityMainThreadDispatcher> unityMainThreadDispatcherMock;
+
+        protected Mock<ITrackedSubskeleton> trackedSubskeletonMock;
+        protected Mock<IPoseSubskeleton> poseSubskeletonMock;
 
         [OneTimeSetUp]
         public virtual void OneTimeSetup()
@@ -176,6 +182,18 @@ namespace PlayMode_Tests.UserCapture.Skeletons.CDK
         [Test]
         public void UpdateBones()
         {
+            // given
+            var frameDto = new UserTrackingFrameDto();
+            trackedSubskeletonMock.Setup(x => x.UpdateBones(It.IsAny<UserTrackingFrameDto>()));
+            poseSubskeletonMock.Setup(x => x.UpdateBones(It.IsAny<UserTrackingFrameDto>()));
+
+            // when
+            abstractSkeleton.UpdateBones(frameDto);
+
+            // then
+            Assert.AreEqual(frameDto, abstractSkeleton.LastFrame);
+            trackedSubskeletonMock.Verify(x => x.UpdateBones(It.IsAny<UserTrackingFrameDto>()), Times.Once);
+            poseSubskeletonMock.Verify(x => x.UpdateBones(It.IsAny<UserTrackingFrameDto>()), Times.Once);
         }
 
         #endregion UpdateBones

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Skeletons/PersonalSkeleton_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Skeletons/PersonalSkeleton_Test.cs
@@ -40,12 +40,12 @@ namespace PlayMode_Tests.UserCapture.Skeletons.CDK
             trackedSusbskeletonGo = new GameObject("tracked subskeleton");
             var camera = trackedSusbskeletonGo.AddComponent<Camera>();
 
-            var trackedSubskeletonMock = new Mock<ITrackedSubskeleton>();
+            trackedSubskeletonMock = new Mock<ITrackedSubskeleton>();
             trackedSubskeletonMock.Setup(x => x.Hips).Returns(trackedSusbskeletonGo.transform);
             trackedSubskeletonMock.Setup(x => x.ViewPoint).Returns(camera);
 
-            var poseSkeletonMock = new Mock<IPoseSubskeleton>();
-            abstractSkeleton.Init(trackedSubskeletonMock.Object, poseSkeletonMock.Object);
+            poseSubskeletonMock = new Mock<IPoseSubskeleton>();
+            abstractSkeleton.Init(trackedSubskeletonMock.Object, poseSubskeletonMock.Object);
         }
 
         public override void TearDown()

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Skeletons/PersonalSkeleton_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Skeletons/PersonalSkeleton_Test.cs
@@ -14,13 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using Moq;
 using NUnit.Framework;
+using System.Threading;
 using umi3d.cdk.userCapture;
+using umi3d.cdk.userCapture.pose;
+using umi3d.cdk.userCapture.tracking;
+using UnityEngine;
 
 namespace PlayMode_Tests.UserCapture.Skeletons.CDK
 {
+    [TestFixture, TestOf(typeof(PersonalSkeleton))]
     public class PersonalSkeleton_Test : AbstractSkeleton_Test
     {
+        GameObject trackedSusbskeletonGo;
+
         [SetUp]
         public override void SetUp()
         {
@@ -28,6 +36,30 @@ namespace PlayMode_Tests.UserCapture.Skeletons.CDK
 
             abstractSkeleton = skeletonGo.AddComponent<PersonalSkeleton>();
             abstractSkeleton.SkeletonHierarchy = new(null);
+
+            trackedSusbskeletonGo = new GameObject("tracked subskeleton");
+            var camera = trackedSusbskeletonGo.AddComponent<Camera>();
+
+            var trackedSubskeletonMock = new Mock<ITrackedSubskeleton>();
+            trackedSubskeletonMock.Setup(x => x.Hips).Returns(trackedSusbskeletonGo.transform);
+            trackedSubskeletonMock.Setup(x => x.ViewPoint).Returns(camera);
+
+            var poseSkeletonMock = new Mock<IPoseSubskeleton>();
+            abstractSkeleton.Init(trackedSubskeletonMock.Object, poseSkeletonMock.Object);
+        }
+
+        public override void TearDown()
+        {
+            base.TearDown();
+
+            Object.Destroy(trackedSusbskeletonGo);
+        }
+
+
+        [Test]
+        public void GetFrame_Test()
+        {
+
         }
     }
 }

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Skeletons/PersonalSkeleton_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Skeletons/PersonalSkeleton_Test.cs
@@ -16,10 +16,10 @@ limitations under the License.
 
 using Moq;
 using NUnit.Framework;
-using System.Threading;
 using umi3d.cdk.userCapture;
 using umi3d.cdk.userCapture.pose;
 using umi3d.cdk.userCapture.tracking;
+using umi3d.common.userCapture.tracking;
 using UnityEngine;
 
 namespace PlayMode_Tests.UserCapture.Skeletons.CDK
@@ -27,7 +27,9 @@ namespace PlayMode_Tests.UserCapture.Skeletons.CDK
     [TestFixture, TestOf(typeof(PersonalSkeleton))]
     public class PersonalSkeleton_Test : AbstractSkeleton_Test
     {
-        GameObject trackedSusbskeletonGo;
+        private GameObject trackedSusbskeletonGo;
+
+        private PersonalSkeleton PersonalSkeleton => abstractSkeleton as PersonalSkeleton;
 
         [SetUp]
         public override void SetUp()
@@ -55,11 +57,26 @@ namespace PlayMode_Tests.UserCapture.Skeletons.CDK
             Object.Destroy(trackedSusbskeletonGo);
         }
 
+        #region GetFrame
 
         [Test]
-        public void GetFrame_Test()
+        public void GetFrame()
         {
+            // when
+            trackedSubskeletonMock.Setup(x => x.WriteTrackingFrame(It.IsAny<UserTrackingFrameDto>(), It.IsAny<TrackingOption>()));
+            poseSubskeletonMock.Setup(x => x.WriteTrackingFrame(It.IsAny<UserTrackingFrameDto>(), It.IsAny<TrackingOption>()));
 
+            // given
+            var frame = PersonalSkeleton.GetFrame(null);
+
+            // then
+            Assert.IsTrue(PersonalSkeleton.gameObject.transform.position == frame.position.Struct(), "Positions are not the same");
+            Assert.IsTrue(PersonalSkeleton.gameObject.transform.rotation == frame.rotation.Quaternion(), "Rotations are not the same");
+            Assert.AreEqual(frame, PersonalSkeleton.LastFrame);
+            trackedSubskeletonMock.Verify(x => x.WriteTrackingFrame(It.IsAny<UserTrackingFrameDto>(), It.IsAny<TrackingOption>()), Times.Once);
+            poseSubskeletonMock.Verify(x => x.WriteTrackingFrame(It.IsAny<UserTrackingFrameDto>(), It.IsAny<TrackingOption>()), Times.Once);
         }
+
+        #endregion GetFrame
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/UserCapture/CollaborativeSkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/UserCapture/CollaborativeSkeleton.cs
@@ -30,8 +30,7 @@ namespace umi3d.cdk.collaboration.userCapture
 
         private void Update()
         {
-            transform.position = posExtrapolator.Extrapolate();
-            transform.rotation = rotExtrapolator.Extrapolate();
+            transform.SetPositionAndRotation(posExtrapolator.Extrapolate(), rotExtrapolator.Extrapolate());
         }
 
         public override void UpdateBones(UserTrackingFrameDto frame)

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
@@ -263,9 +263,9 @@ namespace umi3d.cdk.userCapture
         }
 
 
-        public void AddSubskeleton(ISubskeleton subskeleton)
+        public void AddSubskeleton(IAnimatedSubskeleton animatedSubskeleton)
         {
-            if (subskeleton is not AnimatedSubskeleton animatedSubskeleton)
+            if (animatedSubskeleton == null)
                 return;
 
             lock (SubskeletonsLock) // loader can start parallel async tasks, required to load concurrently
@@ -278,9 +278,9 @@ namespace umi3d.cdk.userCapture
             }
         }
 
-        public void RemoveSubskeleton(ISubskeleton subskeleton)
+        public void RemoveSubskeleton(IAnimatedSubskeleton animatedSubskeleton)
         {
-            if (subskeleton is not AnimatedSubskeleton animatedSubskeleton)
+            if (animatedSubskeleton == null)
                 return;
 
             if (animatedSubskeleton.SelfUpdatedAnimatorParameters.Count > 0)

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
@@ -273,7 +273,7 @@ namespace umi3d.cdk.userCapture
                 subskeletons.AddSorted(animatedSubskeleton);
 
                 // if some animator parameters should be updated by the browsers itself, start listening to them
-                if (animatedSubskeleton.SelfUpdatedAnimatorParameters.Length > 0)
+                if (animatedSubskeleton.SelfUpdatedAnimatorParameters.Count > 0)
                     animatedSubskeleton.StartParameterSelfUpdate(this);
             }
         }
@@ -283,7 +283,7 @@ namespace umi3d.cdk.userCapture
             if (subskeleton is not AnimatedSubskeleton animatedSubskeleton)
                 return;
 
-            if (animatedSubskeleton.SelfUpdatedAnimatorParameters.Length > 0)
+            if (animatedSubskeleton.SelfUpdatedAnimatorParameters.Count > 0)
                 animatedSubskeleton.StopParameterSelfUpdate();
 
             if (subskeletons.Contains(animatedSubskeleton))

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
@@ -37,6 +37,8 @@ namespace umi3d.cdk.userCapture
     {
         protected const DebugScope scope = DebugScope.CDK | DebugScope.UserCapture;
 
+        #region Fields
+
         /// <inheritdoc/>
         public virtual IDictionary<uint, ISkeleton.Transformation> Bones { get; protected set; } = new Dictionary<uint, ISkeleton.Transformation>();
 
@@ -76,11 +78,12 @@ namespace umi3d.cdk.userCapture
         /// <summary>
         /// Subskeleton updated from tracked controllers.
         /// </summary>
-        public ITrackedSubskeleton TrackedSubskeleton => trackedSkeleton;
+        public ITrackedSubskeleton TrackedSubskeleton => _trackedSkeleton;
+        protected ITrackedSubskeleton _trackedSkeleton;
 
         [SerializeField]
         protected TrackedSubskeleton trackedSkeleton;
-
+        
         /// <summary>
         /// Susbskeleton for body poses.
         /// </summary>
@@ -96,9 +99,11 @@ namespace umi3d.cdk.userCapture
         [SerializeField, Tooltip("Anchor of the skeleton hierarchy.")]
         protected Transform hipsAnchor;
 
-        public void Init(TrackedSubskeleton trackedSkeleton, IPoseSubskeleton poseSkeleton)
+        #endregion Fields
+
+        public void Init(ITrackedSubskeleton trackedSkeleton, IPoseSubskeleton poseSkeleton)
         {
-            this.trackedSkeleton = trackedSkeleton;
+            this._trackedSkeleton = trackedSkeleton;
             HipsAnchor = TrackedSubskeleton.Hips;
             PoseSubskeleton = poseSkeleton;
             subskeletons = new List<ISubskeleton> { TrackedSubskeleton };

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
@@ -40,7 +40,9 @@ namespace umi3d.cdk.userCapture
         /// <inheritdoc/>
         public virtual IDictionary<uint, ISkeleton.Transformation> Bones { get; protected set; } = new Dictionary<uint, ISkeleton.Transformation>();
 
-
+        /// <summary>
+        /// Lock for concurrent access to <see cref="Subskeletons"/> collection.
+        /// </summary>
         public object SubskeletonsLock { get; } = new();
 
         /// <inheritdoc/>

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Animation/Loader/SkeletonAnimationNodeLoader.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Animation/Loader/SkeletonAnimationNodeLoader.cs
@@ -308,8 +308,8 @@ namespace umi3d.cdk.userCapture.animation
                 {
                     foreach (var subskeleton in skeleton.Subskeletons.ToList())
                     {
-                        if (subskeleton is AnimatedSubskeleton)
-                            skeleton.RemoveSubskeleton(subskeleton);
+                        if (subskeleton is IAnimatedSubskeleton animatedSubskeleton)
+                            skeleton.RemoveSubskeleton(animatedSubskeleton);
                     }
                     clientServer.OnLeavingEnvironment.RemoveListener(RemoveSkeletons);
                     isRegisteredForPersonalSkeletonCleanup = false;

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Animation/Object/AnimatedSubskeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Animation/Object/AnimatedSubskeleton.cs
@@ -30,32 +30,23 @@ namespace umi3d.cdk.userCapture.animation
     /// <summary>
     /// Subskeleton that is the target if a skeleton animation, using an Animator.
     /// </summary>
-    public class AnimatedSubskeleton : ISubskeleton
+    public class AnimatedSubskeleton : IAnimatedSubskeleton
     {
         private const DebugScope DEBUG_SCOPE = DebugScope.CDK | DebugScope.Animation | DebugScope.UserCapture;
 
         #region Properties
 
-        /// <summary>
-        /// Reference to the skeleton mapper that computes related links into a pose.
-        /// </summary>
+        /// <inheritdoc/>
         public virtual ISkeletonMapper Mapper { get; protected set; }
 
-        /// <summary>
-        /// Priority level of the animated skeleton.
-        /// </summary>
+        /// <inheritdoc/>
         public virtual int Priority { get; protected set; }
 
-        /// <summary>
-        /// Animation id of the animated skeleton.
-        /// </summary>
+        /// <inheritdoc/>
         public virtual IReadOnlyList<UMI3DAnimatorAnimation> Animations => animations;
         private readonly List<UMI3DAnimatorAnimation> animations;
 
-        /// <summary>
-        /// Parameters required by the animator that are updated by the browser itself.
-        /// </summary>
-        /// The key correspond to a key in <see cref="SkeletonAnimatorParameterKeys"/>.
+        /// <inheritdoc/>
         public virtual IReadOnlyList<SkeletonAnimationParameter> SelfUpdatedAnimatorParameters => selfUpdatedAnimatorParameters;
         private readonly List<SkeletonAnimationParameter> selfUpdatedAnimatorParameters;
 
@@ -182,9 +173,7 @@ namespace umi3d.cdk.userCapture.animation
 
         #region ParameterSelfUpdate
 
-        /// <summary>
-        /// Start animation parameters self update. Parameters are recomputed each frame based on the <paramref name="skeleton"/> movement.
-        /// </summary>
+        /// <inheritdoc/>
         public virtual void StartParameterSelfUpdate(ISkeleton skeleton)
         {
             if (skeleton == null)
@@ -201,9 +190,7 @@ namespace umi3d.cdk.userCapture.animation
             }
         }
 
-        /// <summary>
-        /// Stop animation parameters self update.
-        /// </summary>
+        /// <inheritdoc/>
         public virtual void StopParameterSelfUpdate()
         {
             unityMainThreadDispatcher.Enqueue(() =>
@@ -228,7 +215,7 @@ namespace umi3d.cdk.userCapture.animation
             while (skeleton != null)
             {
                 var lastFrame = skeleton.LastFrame;
-                if(lastFrame == null)
+                if (lastFrame == null)
                 {
                     UnityEngine.Debug.Log("No frame");
                     yield return null;
@@ -245,15 +232,15 @@ namespace umi3d.cdk.userCapture.animation
                     (UMI3DAnimatorParameterType typeKey, object valueParameter) = parameter.parameterKey switch
                     {
                         (uint)SkeletonAnimatorParameterKeys.SPEED => (UMI3DAnimatorParameterType.Float, lastFrame.speed.Struct().magnitude),
-                        (uint)SkeletonAnimatorParameterKeys.SPEED_X => ( UMI3DAnimatorParameterType.Float, lastFrame.speed.X),
-                        (uint)SkeletonAnimatorParameterKeys.SPEED_ABS_X => ( UMI3DAnimatorParameterType.Float, Mathf.Abs(lastFrame.speed.X)),
-                        (uint)SkeletonAnimatorParameterKeys.SPEED_Y => ( UMI3DAnimatorParameterType.Float, lastFrame.speed.Y),
-                        (uint)SkeletonAnimatorParameterKeys.SPEED_ABS_Y => ( UMI3DAnimatorParameterType.Float, Mathf.Abs(lastFrame.speed.Y)),
-                        (uint)SkeletonAnimatorParameterKeys.SPEED_Z => ( UMI3DAnimatorParameterType.Float, lastFrame.speed.Z),
+                        (uint)SkeletonAnimatorParameterKeys.SPEED_X => (UMI3DAnimatorParameterType.Float, lastFrame.speed.X),
+                        (uint)SkeletonAnimatorParameterKeys.SPEED_ABS_X => (UMI3DAnimatorParameterType.Float, Mathf.Abs(lastFrame.speed.X)),
+                        (uint)SkeletonAnimatorParameterKeys.SPEED_Y => (UMI3DAnimatorParameterType.Float, lastFrame.speed.Y),
+                        (uint)SkeletonAnimatorParameterKeys.SPEED_ABS_Y => (UMI3DAnimatorParameterType.Float, Mathf.Abs(lastFrame.speed.Y)),
+                        (uint)SkeletonAnimatorParameterKeys.SPEED_Z => (UMI3DAnimatorParameterType.Float, lastFrame.speed.Z),
                         (uint)SkeletonAnimatorParameterKeys.SPEED_ABS_Z => (UMI3DAnimatorParameterType.Float, Mathf.Abs(lastFrame.speed.Z)),
-                        (uint)SkeletonAnimatorParameterKeys.SPEED_X_Z => (  UMI3DAnimatorParameterType.Float, Vector3.ProjectOnPlane(lastFrame.speed.Struct(), Vector3.up).magnitude),
-                        (uint)SkeletonAnimatorParameterKeys.JUMP => ( UMI3DAnimatorParameterType.Bool, (object)lastFrame.jumping),
-                        (uint)SkeletonAnimatorParameterKeys.CROUCH => ( UMI3DAnimatorParameterType.Bool, (object)lastFrame.crouching),
+                        (uint)SkeletonAnimatorParameterKeys.SPEED_X_Z => (UMI3DAnimatorParameterType.Float, Vector3.ProjectOnPlane(lastFrame.speed.Struct(), Vector3.up).magnitude),
+                        (uint)SkeletonAnimatorParameterKeys.JUMP => (UMI3DAnimatorParameterType.Bool, (object)lastFrame.jumping),
+                        (uint)SkeletonAnimatorParameterKeys.CROUCH => (UMI3DAnimatorParameterType.Bool, (object)lastFrame.crouching),
                         _ => default
                     };
 
@@ -324,10 +311,10 @@ namespace umi3d.cdk.userCapture.animation
             {
                 case UMI3DAnimatorParameterType.Bool:
                     return IsChangeSignificant((bool)previousValue, (bool)newValue);
-                    
+
                 case UMI3DAnimatorParameterType.Float:
                     return IsChangeSignificant((float)previousValue, (float)newValue, threshold);
-                    
+
                 case UMI3DAnimatorParameterType.Integer:
                     return IsChangeSignificant((int)previousValue, (int)newValue);
             }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Animation/Object/IAnimatedSubskeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Animation/Object/IAnimatedSubskeleton.cs
@@ -1,0 +1,53 @@
+﻿/*
+Copyright 2019 - 2023 Inetum
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System.Collections.Generic;
+using umi3d.common.userCapture.description;
+
+namespace umi3d.cdk.userCapture.animation
+{
+    /// <summary>
+    /// Subskeleton that is the target if a skeleton animation, using an Animator.
+    /// </summary>
+    public interface IAnimatedSubskeleton : ISubskeleton
+    {
+        /// <summary>
+        /// Animation id of the animated skeleton.
+        /// </summary>
+        IReadOnlyList<UMI3DAnimatorAnimation> Animations { get; }
+
+        /// <summary>
+        /// Reference to the skeleton mapper that computes related links into a pose.
+        /// </summary>
+        ISkeletonMapper Mapper { get; }
+
+        /// <summary>
+        /// Parameters required by the animator that are updated by the browser itself.
+        /// </summary>
+        /// The key correspond to a key in <see cref="SkeletonAnimatorParameterKeys"/>.
+        IReadOnlyList<AnimatedSubskeleton.SkeletonAnimationParameter> SelfUpdatedAnimatorParameters { get; }
+
+        /// <summary>
+        /// Start animation parameters self update. Parameters are recomputed each frame based on the <paramref name="skeleton"/> movement.
+        /// </summary>
+        void StartParameterSelfUpdate(ISkeleton skeleton);
+
+        /// <summary>
+        /// Stop animation parameters self update.
+        /// </summary>
+        void StopParameterSelfUpdate();
+    }
+}

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Animation/Object/IAnimatedSubskeleton.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Animation/Object/IAnimatedSubskeleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53086009c2edf8e4186fb1e7157fd3ee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Interfaces/ISkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Interfaces/ISkeleton.cs
@@ -16,6 +16,7 @@ limitations under the License.
 
 using System;
 using System.Collections.Generic;
+using umi3d.cdk.userCapture.animation;
 using umi3d.cdk.userCapture.pose;
 using umi3d.cdk.userCapture.tracking;
 using umi3d.common.userCapture;
@@ -90,13 +91,13 @@ namespace umi3d.cdk.userCapture
         /// Add a subskeleton to the skeleton.
         /// </summary>
         /// <param name="subskeleton"></param>
-        void AddSubskeleton(ISubskeleton subskeleton);
+        void AddSubskeleton(IAnimatedSubskeleton subskeleton);
 
         /// <summary>
         /// Add a subskeleton to the skeleton.
         /// </summary>
         /// <param name="subskeleton"></param>
-        void RemoveSubskeleton(ISubskeleton subskeleton);
+        void RemoveSubskeleton(IAnimatedSubskeleton subskeleton);
 
         #region Data struture
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/PersonalSkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/PersonalSkeleton.cs
@@ -68,15 +68,15 @@ namespace umi3d.cdk.userCapture
         /// <inheritdoc/>
         public override void UpdateBones(UserTrackingFrameDto frame)
         {
-            if (Subskeletons != null)
+            lock(SubskeletonsLock)
             {
-                lock(SubskeletonsLock)
-                    foreach (ISubskeleton skeleton in Subskeletons)
-                    {
-                        if (skeleton is IWritableSubskeleton writableSkeleton)
-                            writableSkeleton.UpdateBones(frame);
-                    }
+                foreach (ISubskeleton skeleton in Subskeletons)
+                {
+                    if (skeleton is IWritableSubskeleton writableSkeleton)
+                        writableSkeleton.UpdateBones(frame);
+                }
             }
+
             lastFrame = frame;
         }
     }

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Animation/SkeletonAnimatorSelfUpdate/SkeletonAnimationParameterDto.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Animation/SkeletonAnimatorSelfUpdate/SkeletonAnimationParameterDto.cs
@@ -36,7 +36,7 @@ namespace umi3d.common.userCapture.animation
         /// Ranges to clamp value to a constant result when in an interval. <br/>
         /// "If no range is defined, the parameter value is directly given to the animator.
         /// </summary>
-        public RangeDto[] ranges { get; set; }
+        public RangeDto[] ranges { get; set; } = new RangeDto[0];
 
         /// <summary>
         ///  Ranges to clamp value to a certain result when in an interval.

--- a/UMI3D-SDK/Assets/UMI3D SDK/Dependencies/Runtime/Inetum-Unity-Utils/Extension/IEnumerableExtension.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Dependencies/Runtime/Inetum-Unity-Utils/Extension/IEnumerableExtension.cs
@@ -261,25 +261,37 @@ namespace inetum.unityUtils
         /// <param name="item"></param>
         public static void AddSorted<T>(this List<T> source, T item) where T : IComparable<T>
         {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
             if (source.Count == 0)
             {
                 source.Add(item);
                 return;
             }
-            if (source[source.Count - 1].CompareTo(item) <= 0)
+            try
             {
-                source.Add(item);
-                return;
+                if (source[^1].CompareTo(item) <= 0)
+                {
+                    source.Add(item);
+                    return;
+                }
+                if (source[0].CompareTo(item) >= 0)
+                {
+                    source.Insert(0, item);
+                    return;
+                }
+                int index = source.BinarySearch(item);
+                if (index < 0)
+                    index = ~index;
+
+                source.Insert(index, item);
             }
-            if (source[0].CompareTo(item) >= 0)
+            catch (NullReferenceException ex) 
             {
-                source.Insert(0, item);
-                return;
+                throw new NullReferenceException("An element of the list is null and could not be compared.\n"+ex.Message);
             }
-            int index = source.BinarySearch(item);
-            if (index < 0)
-                index = ~index;
-            source.Insert(index, item);
         }
 
     }


### PR DESCRIPTION
Add unit tests on AbstractSkeleton, PersonalSkeleton and CollaborativeSkeleton

-> AnimatedSubskeleton receives an IAnimatedSubskeleton interface, which makes it possible to clean up some signatures, to mock simply, and to avoid having to check whether the sub-skeleton is indeed an animatedSubskeleton in the ISkeleton.AddSubskeleton.

-> As a result, I've passed the public arrays of the IAnimatedSubskeleton to IReadOnlyList. Better in terms of accessibility, negligible performance degradation in this case, and easier to debug.