### PR TITLE
BUG_8450 Check that bone transform is not null

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Animation/Loader/SkeletonAnimationNodeLoader.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Animation/Loader/SkeletonAnimationNodeLoader.cs
@@ -208,7 +208,9 @@ namespace umi3d.cdk.userCapture.animation
             }
 
             // create link for each rig. May be improved with distance analysis for more complex links
-            skeletonMapper.Mappings = boneUnityMapping.Select(b => new SkeletonMapping(b.umi3dBoneType, new GameNodeLink(b.transform))).ToArray();
+            skeletonMapper.Mappings = (from bone in boneUnityMapping
+                                       where bone.transform != null
+                                       select new SkeletonMapping(bone.umi3dBoneType, new GameNodeLink(bone.transform))).ToArray();
 
             return skeletonMapper;
         }

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Description/SkeletonMapping/SkeletonMapper.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Description/SkeletonMapping/SkeletonMapper.cs
@@ -23,7 +23,7 @@ using UnityEngine;
 namespace umi3d.common.userCapture.description
 {
     /// <summary>
-    /// Mapper between any skeleton hiearchy and the UMI3D one.
+    /// Mapper between any skeleton hierarchy and the UMI3D one.
     /// </summary>
     public class SkeletonMapper : MonoBehaviour, ISkeletonMapper
     {
@@ -47,7 +47,7 @@ namespace umi3d.common.userCapture.description
             return new SubSkeletonPoseDto()
             {
                 boneAnchor = BoneAnchor,
-                bones = Mappings.Select(b => GetBonePose(hierarchy,b).subBone).Where(b => b != null).ToList()
+                bones = Mappings.Select(b => GetBonePose(hierarchy, b).subBone).Where(b => b != null).ToList()
             };
         }
 
@@ -57,7 +57,7 @@ namespace umi3d.common.userCapture.description
                 throw new ArgumentNullException(nameof(mapping));
 
             uint boneType = mapping.BoneType;
-            
+
             if (computedMap.ContainsKey(boneType))
                 return computedMap[boneType];
 


### PR DESCRIPTION
Happened for eyes, that are defined in UMI3D standard hierarchy but not in animator, when generating hierarchy from animator