### PR TITLE
Init computed bones with skeletonhierarchy

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
@@ -109,6 +109,20 @@ namespace umi3d.cdk.userCapture
             HipsAnchor = TrackedSubskeleton.Hips;
             PoseSubskeleton = poseSkeleton;
             subskeletons = new List<ISubskeleton> { TrackedSubskeleton };
+
+            // init bones to prevent from early bindings arrival
+            foreach (var boneType in SkeletonHierarchy.Relations.Keys)
+            {
+                Bones[boneType] = new ISkeleton.Transformation()
+                {
+                    Position = Vector3.zero,
+                    Rotation = Quaternion.identity,
+                    LocalRotation = Quaternion.identity,
+                };
+            }
+            Bones[BoneType.Hips].Position = HipsAnchor != null ? HipsAnchor.position : Vector3.zero;
+            Bones[BoneType.Hips].Rotation = HipsAnchor != null ? HipsAnchor.rotation : Quaternion.identity;
+
             StartCoroutine(InitPoseSubskeleton());
         }
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/IPersonalSkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/IPersonalSkeleton.cs
@@ -33,6 +33,11 @@ namespace umi3d.cdk.userCapture
         Vector3 worldSize { get; }
 
         /// <summary>
+        /// Skeleton Initialization.
+        /// </summary>
+        public void SelfInit();
+
+        /// <summary>
         /// Write a tracking frame from all <see cref="IWritableSubskeleton"/>.
         /// </summary>
         /// <param name="option"></param>

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/PersonalSkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/PersonalSkeleton.cs
@@ -40,6 +40,11 @@ namespace umi3d.cdk.userCapture
         {
             PoseSubskeleton = new PoseSubskeleton();
 
+            //Init(trackedSkeleton, PoseSubskeleton);
+        }
+
+        public void SelfInit()
+        {
             Init(trackedSkeleton, PoseSubskeleton);
         }
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/PersonalSkeletonManager.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/PersonalSkeletonManager.cs
@@ -108,6 +108,7 @@ namespace umi3d.cdk.userCapture
 
             PersonalSkeleton = environmentManager.gameObject.GetComponentInChildren<PersonalSkeleton>();
             _skeleton.SkeletonHierarchy = StandardHierarchy;
+            PersonalSkeleton.SelfInit();
             computeRoutine ??= lateRoutineService.AttachLateRoutine(ComputeCoroutine());
         }
 


### PR DESCRIPTION
Allowing the support of bindings arriving before the first iteration of Compute()