### PR TITLE
Rollback to normal local transform assignement

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Animation/Loader/SkeletonAnimationNodeLoader.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Animation/Loader/SkeletonAnimationNodeLoader.cs
@@ -271,7 +271,8 @@ namespace umi3d.cdk.userCapture.animation
                     var (position, rotation, scale) = animatorBoneInfos[animatorRigNames];
 
                     boneTransform.name = animatorRigNames;
-                    boneTransform.SetLocalPositionAndRotation(position, rotation);
+                    boneTransform.localPosition = position;
+                    boneTransform.localRotation = rotation;
                     boneTransform.localScale = scale;
                 }
                 else // case that occurs if the umi3d bone is not found in animator hierarchy, lift children up and delete parent.


### PR DESCRIPTION
SetLocalPositionAndRotation is not supported on Unity 2021.3.8f, it was introduced on 2021.3.11f.