### PR TITLE
Load some animator as self-caring ones

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/UMI3DAnimatorAnimation.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/UMI3DAnimatorAnimation.cs
@@ -192,9 +192,14 @@ namespace umi3d.cdk
                 IsPaused = true;
                 return;
             }
-            animator.Play(dto.stateName, layer: 0, normalizedTime: nTime);
+            
+            if (dto.stateName != string.Empty) // an empty state name corresponds to a self-caring animator.
+            {
+                animator.Play(dto.stateName, layer: 0, normalizedTime: nTime);
+                trackingAnimationCoroutine ??= coroutineService.AttachCoroutine(TrackEnd());
+            }
+                
             IsPaused = false;
-            trackingAnimationCoroutine ??= coroutineService.AttachCoroutine(TrackEnd());
             UMI3DClientServer.Instance.OnLeavingEnvironment.AddListener(StopTracking);
         }
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/Animation/UMI3DAnimatorAnimation.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/Animation/UMI3DAnimatorAnimation.cs
@@ -32,10 +32,12 @@ namespace umi3d.edk
         [SerializeField, EditorReadOnly, Tooltip("Node where the animator can be found on.")]
         private UMI3DNode node = null;
         /// <summary>
-        /// Aniumation state's name in the animator controller.
+        /// Animation state's name in the animator controller.
         /// </summary>
-        [SerializeField, EditorReadOnly, Tooltip("Current state's name in the animator controller.")]
-        private string stateName = "";
+        /// An empty state name corresponds to a self-caring animator.
+        [SerializeField, EditorReadOnly, Tooltip("Current state's name in the animator controller. \n" +
+                                                 "An empty state name corresponds to a self-caring animator.")]
+        private string stateName = string.Empty;
         
         /// <summary>
         /// Animation normalized time at start. 


### PR DESCRIPTION
When using an empty statename, the animator is considered as self-caring and won't track its own end after being loaded.