### PR TITLE
BUG 8642 Remove finished coroutines

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/Dependencies/Runtime/Inetum-Unity-Utils/Coroutines/CoroutineManagerMono.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Dependencies/Runtime/Inetum-Unity-Utils/Coroutines/CoroutineManagerMono.cs
@@ -58,6 +58,8 @@ namespace inetum.unityUtils
 
         public void DetachLateRoutine(IEnumerator routine)
         {
+            if (!routines.Contains(routine) || routinesToRemove.Contains(routine))
+                return;
             routinesToRemove.Enqueue(routine);
         }
 
@@ -82,7 +84,8 @@ namespace inetum.unityUtils
             }
 
             foreach (var routine in routines)
-                routine.MoveNext();
+                if (!routine.MoveNext())
+                    DetachLateRoutine(routine);
         }
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/Dependencies/Runtime/Inetum-Unity-Utils/Coroutines/PersistentCoroutineManagerMono.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Dependencies/Runtime/Inetum-Unity-Utils/Coroutines/PersistentCoroutineManagerMono.cs
@@ -58,6 +58,8 @@ namespace inetum.unityUtils
 
         public void DetachLateRoutine(IEnumerator routine)
         {
+            if (!routines.Contains(routine) || routinesToRemove.Contains(routine))
+                return;
             routinesToRemove.Enqueue(routine);
         }
 
@@ -82,7 +84,8 @@ namespace inetum.unityUtils
             }
 
             foreach (var routine in routines)
-                routine.MoveNext();
+                if (!routine.MoveNext())
+                    DetachLateRoutine(routine);
         }
     }
 }


### PR DESCRIPTION
When a coroutine reaches its end, the current manager will still keep the registered coroutine all call it every frame not to do anything. With this PR it won't be the case anymore. This PR also add security so that when a user try to remove a coroutine that has not been registered, the API won't crash.