### PR TITLE
Adapting PoseAnimator, Editor & DTO for Snapping

### DIFF
--- a/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Pose/Services/PoseManager_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Pose/Services/PoseManager_Test.cs
@@ -4,6 +4,7 @@ using System;
 using umi3d.cdk;
 using umi3d.cdk.userCapture;
 using umi3d.cdk.userCapture.pose;
+using umi3d.common;
 using umi3d.common.userCapture.description;
 using umi3d.common.userCapture.pose;
 
@@ -68,8 +69,9 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
             Mock<PoseAnimator> poseAnimatorMock = new (dto, new PoseClip(new()), new IPoseCondition[0]);
 
             poseAnimatorMock.Setup(x=>x.TryActivate()).Returns(true);
-            environmentServiceMock.Setup(x => x.GetEntityObject<PoseAnimator>(0,dto.id)).Returns(poseAnimatorMock.Object);
-
+            PoseAnimator pA = poseAnimatorMock.Object;
+            environmentServiceMock.Setup(x => x.TryGetEntity(UMI3DGlobalID.EnvironmentId, dto.id, out pA)).Returns(true);
+            
             var personalSkeletonMock = new Mock<IPersonalSkeleton>();
             var poseSubskeletonMock = new Mock<IPoseSubskeleton>();
             skeletonManagerServiceMock.Setup(x => x.PersonalSkeleton).Returns(personalSkeletonMock.Object);

--- a/UMI3D-SDK/Assets/Tests/EditMode_Tests/Common/UserCapture/Pose/Serializer/PoseConditionSerializerModule_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/EditMode_Tests/Common/UserCapture/Pose/Serializer/PoseConditionSerializerModule_Test.cs
@@ -169,10 +169,9 @@ namespace EditMode_Tests.UserCapture.Pose.Common
 
             poseConditionSerializerModule.Read(byteContainer, out bool readable, out AbstractPoseConditionDto result);
             Assert.IsTrue(readable);
-            Assert.IsTrue(((result as OrConditionDto).ConditionA as MagnitudeConditionDto).Magnitude
-                == (orConditionDto.ConditionA as MagnitudeConditionDto).Magnitude);
-            Assert.IsTrue(((result as OrConditionDto).ConditionB as ScaleConditionDto).Scale.X
-                == (orConditionDto.ConditionB as ScaleConditionDto).Scale.X);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(((result as OrConditionDto).ConditionA as MagnitudeConditionDto).Magnitude, (orConditionDto.ConditionA as MagnitudeConditionDto).Magnitude);
+            Assert.AreEqual(((result as OrConditionDto).ConditionB as ScaleConditionDto).Scale.X, (orConditionDto.ConditionB as ScaleConditionDto).Scale.X);
         }
 
         [Test]
@@ -189,11 +188,8 @@ namespace EditMode_Tests.UserCapture.Pose.Common
 
             poseConditionSerializerModule.Read(byteContainer, out bool readable, out AbstractPoseConditionDto result);
             Assert.IsTrue(readable);
-
-            Assert.IsTrue(((result as NotConditionDto).Condition as ScaleConditionDto).Scale.X
-                == (notConditionDto.Condition as ScaleConditionDto).Scale.X);
-            Assert.IsTrue(((result as NotConditionDto).Condition as DirectionConditionDto).Direction.X
-                == (notConditionDto.Condition as DirectionConditionDto).Direction.X);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(((result as NotConditionDto).Condition as DirectionConditionDto).Direction.X, (notConditionDto.Condition as DirectionConditionDto).Direction.X);
         }
 
         #endregion Multy Conditions

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PoseAnimator/PoseAnimator.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PoseAnimator/PoseAnimator.cs
@@ -17,6 +17,7 @@ limitations under the License.
 using inetum.unityUtils;
 using System;
 using System.Collections;
+using umi3d.common.userCapture.description;
 using umi3d.common.userCapture.pose;
 using UnityEngine;
 
@@ -44,6 +45,16 @@ namespace umi3d.cdk.userCapture.pose
         /// </summary>
         public PoseClip PoseClip => poseClip;
         private PoseClip poseClip;
+
+        /// <summary>
+        /// See <see cref="PoseClipDto.pose"/>.
+        /// </summary>
+        public PoseAnchorDto Anchor => dto.anchor;
+
+        /// <summary>
+        /// See <see cref="PoseClipDto.isAnchored"/>.
+        /// </summary>
+        public bool IsAnchored => dto.isAnchored;
 
         public ulong RelativeNodeId => dto.relatedNodeId;
 
@@ -186,7 +197,7 @@ namespace umi3d.cdk.userCapture.pose
         private void Apply()
         {
             IsApplied = true;
-            poseService.PlayPoseClip(poseClip);
+            poseService.PlayPoseClip(poseClip, Anchor);
             ConditionsValidated?.Invoke();
             StartWatchEndOfConditions();
         }
@@ -221,7 +232,9 @@ namespace umi3d.cdk.userCapture.pose
 
                 // check to enable/disable auto-watched poses (nonInteractional)
                 if (!IsApplied && CheckConditions())
+                {
                     Apply();
+                }
             }
             StopWatchActivationConditions();
         }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PoseClip.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PoseClip.cs
@@ -33,11 +33,6 @@ namespace umi3d.cdk.userCapture.pose
         public ulong Id => dto.id;
 
         /// <summary>
-        /// See <see cref="PoseClipDto.pose"/>.
-        /// </summary>
-        public PoseAnchorDto Anchor => dto.pose.anchor;
-
-        /// <summary>
         /// See <see cref="PoseDto.bones"/>.
         /// </summary>
         public List<BoneDto> Bones => dto.pose.bones;

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/PoseSubskeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/PoseSubskeleton.cs
@@ -82,7 +82,10 @@ namespace umi3d.cdk.userCapture.pose
             if (isOverriding)
                 StopAllPoses();
 
-            appliedPoses.Add(poseToAdd);
+            if (!appliedPoses.Contains(poseToAdd))
+                appliedPoses.Add(poseToAdd);
+            else
+                UMI3DLogger.LogWarning($"Pose clip {poseToAdd.Id} is already playing.", DebugScope.CDK | DebugScope.UserCapture);
         }
 
         /// <inheritdoc/>

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Service/IPoseManager.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Service/IPoseManager.cs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using umi3d.common.userCapture.description;
+
 namespace umi3d.cdk.userCapture.pose
 {
     /// <summary>
@@ -25,7 +27,7 @@ namespace umi3d.cdk.userCapture.pose
         /// Sets the related pose in the poseSkeleton
         /// </summary>
         /// <param name="poseClip"></param>
-        void PlayPoseClip(PoseClip poseClip);
+        void PlayPoseClip(PoseClip poseClip, PoseAnchorDto poseAnchorDto = null);
 
         /// <summary>
         /// Stops all poses

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/AbstractSimulatedTracker.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/AbstractSimulatedTracker.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Copyright 2019 - 2021 Inetum
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,19 +19,22 @@ using UnityEngine;
 
 namespace umi3d.cdk.userCapture.tracking
 {
-    public class Tracker : MonoBehaviour
+    public abstract class AbstractSimulatedTracker : Tracker, ISimulatedTracker
     {
-        [EditorReadOnly,SerializeField, ConstEnum(typeof(common.userCapture.BoneType), typeof(uint))]
-        protected uint boneType;
+        uint ISimulatedTracker.Bonetype => Bonetype;
 
-        public uint Bonetype => boneType;
+        public Vector3 PositionOffset => positionOffset;
+        protected Vector3 positionOffset;
 
-        public bool isActif = true;
+        public Quaternion RotationOffset => rotationOffset;
+        protected Quaternion rotationOffset;
 
-        public bool isOverrider = true;
-
-        protected void Awake()
+        protected void Init(uint bonetype, Vector3 posOffset, Quaternion rotOffset)
         {
+            this.boneType = bonetype;
+            this.positionOffset = posOffset;
+            this.rotationOffset = rotOffset;
+
             distantController = new DistantController()
             {
                 boneType = boneType,
@@ -42,15 +45,7 @@ namespace umi3d.cdk.userCapture.tracking
             };
         }
 
-        protected virtual void Update()
-        {
-            distantController.position = transform.position;
-            distantController.rotation = transform.rotation;
-            distantController.isActif = isActif;
-            distantController.isOverrider = isOverrider;
-        }
-
-        public DistantController distantController { get; protected set; }
-
+        void ISimulatedTracker.SimulatePosition() => this.SimulatePosition();
+        protected abstract void SimulatePosition();
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/AbstractSimulatedTracker.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/AbstractSimulatedTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c6ca081f1a4fdb43b4045529d48c191
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/BoneAnchoredSimulatedTracker.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/BoneAnchoredSimulatedTracker.cs
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 - 2021 Inetum
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using UnityEngine;
+
+namespace umi3d.cdk.userCapture.tracking
+{
+    public class BoneAnchoredSimulatedTracker : AbstractSimulatedTracker
+    {
+        private ISkeleton.Transformation boneReference;
+
+        public void Init(ISkeleton.Transformation bone, uint bonetype, Vector3 posOffset, Quaternion rotOffset)
+        {
+            this.boneReference = bone;
+            Init(bonetype, posOffset, rotOffset);
+        }
+
+        protected override void SimulatePosition()
+        {
+            this.transform.rotation = boneReference.Rotation * this.rotationOffset;
+            this.transform.position = boneReference.Position + boneReference.Rotation * (this.positionOffset);
+        }
+
+        protected override void Update()
+        {
+            SimulatePosition();
+            base.Update();
+        }
+    }
+}

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/BoneAnchoredSimulatedTracker.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/BoneAnchoredSimulatedTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45cb0bf041fa7f9409bb56f882cb6195
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/Controller/IController.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/Controller/IController.cs
@@ -32,6 +32,7 @@ namespace umi3d.cdk.userCapture.tracking
 
         public virtual ControllerDto ToControllerDto()
         {
+            // if DTO is null, it will break in serialization
             return boneType == BoneType.None ? null : new ControllerDto { boneType = boneType, position = position.Dto(), rotation = rotation.Dto(), isOverrider = false };
         }
     }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/FloorAnchoredSimulatedTracker.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/FloorAnchoredSimulatedTracker.cs
@@ -1,0 +1,42 @@
+/*
+Copyright 2019 - 2021 Inetum
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using UnityEngine;
+
+namespace umi3d.cdk.userCapture.tracking
+{
+    public class FloorAnchoredSimulatedTracker : AbstractSimulatedTracker
+    {
+        private Transform floorReference;
+
+        public void Init(Transform floor, uint bonetype, Vector3 posOffset, Quaternion rotOffset)
+        {
+            this.floorReference = floor;
+            Init(bonetype, posOffset, rotOffset);
+        }
+
+        protected override void SimulatePosition()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        protected override void Update()
+        {
+            SimulatePosition();
+            base.Update();
+        }
+    }
+}

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/FloorAnchoredSimulatedTracker.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/FloorAnchoredSimulatedTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a5a1480baeffb8340bc6e81fb9c379c3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/ISimulatedTracker.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/ISimulatedTracker.cs
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 - 2021 Inetum
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using inetum.unityUtils;
+using UnityEngine;
+
+namespace umi3d.cdk.userCapture.tracking
+{
+    public interface ISimulatedTracker
+    {
+        uint Bonetype { get; }
+
+        Vector3 PositionOffset { get; }
+
+        Quaternion RotationOffset { get; }
+
+        void SimulatePosition();
+    }
+}

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/ISimulatedTracker.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/ISimulatedTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a141c6a893eaa947ad565474198a404
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/ITrackedSubskeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/ITrackedSubskeleton.cs
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using umi3d.common.userCapture.description;
 using umi3d.common.userCapture.tracking;
 using UnityEngine;
 
@@ -28,5 +30,9 @@ namespace umi3d.cdk.userCapture.tracking
         IReadOnlyDictionary<uint, TrackedSubskeletonBone> TrackedBones { get; }
 
         UserTrackingBoneDto GetController(uint boneType);
+
+        Task StartTrackerSimulation(PoseAnchorDto poseAnchor);
+
+        void StopTrackerSimulation(PoseAnchorDto poseAnchor);
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/NodeAnchoredSimulatedTracker.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/NodeAnchoredSimulatedTracker.cs
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 - 2021 Inetum
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using UnityEngine;
+
+namespace umi3d.cdk.userCapture.tracking
+{
+    public class NodeAnchoredSimulatedTracker : AbstractSimulatedTracker
+    {
+        private Transform nodeReference;
+
+        public void Init(UMI3DNodeInstance node, uint bonetype, Vector3 posOffset, Quaternion rotOffset)
+        {
+            this.nodeReference = node.transform;
+            Init(bonetype, posOffset, rotOffset);
+        }
+
+        protected override void SimulatePosition()
+        {
+            this.transform.rotation = nodeReference.rotation * this.rotationOffset;
+            this.transform.position = nodeReference.position + nodeReference.rotation * (this.positionOffset);
+        }
+
+        protected override void Update()
+        {
+            SimulatePosition();
+            base.Update();
+        }
+    }
+}

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/NodeAnchoredSimulatedTracker.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/NodeAnchoredSimulatedTracker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f714af6d3bc17849ae556bdf90facb8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/DTOs/PoseAnimator/PoseAnchoringType.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/DTOs/PoseAnimator/PoseAnchoringType.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Copyright 2019 - 2023 Inetum
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,33 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-using System.Collections.Generic;
-using umi3d.common.userCapture.description;
-using UnityEngine;
-
 namespace umi3d.common.userCapture.pose
 {
     /// <summary>
-    /// Describes a skeleton pose.
+    /// 
     /// </summary>
-    public interface IUMI3DPoseData
+    [System.Serializable]
+    public enum PoseAnchoringType
     {
         /// <summary>
-        /// The bone that anchor the pose
+        /// 
         /// </summary>
-        PoseAnchorDto Anchor { get; }
+        Node,
 
         /// <summary>
-        /// All the bones that describe the pose
+        /// 
         /// </summary>
-        IList<BoneDto> Bones { get; }
+        Bone,
 
         /// <summary>
-        /// Transforms the Object to its DTO counterpart
+        /// 
         /// </summary>
-        /// <returns></returns>
-        PoseDto ToPoseDto();
-
-        PoseDto ToPoseDto(PoseAnchoringType anchoringType, ulong poseRelativeNodeId, uint poseRelativeBone, Vector3 posOffset, Quaternion rotOffset);
+        Floor
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/DTOs/PoseAnimator/PoseAnchoringType.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/DTOs/PoseAnimator/PoseAnchoringType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 538775ca2c2bebe458dcb6e21cb4460a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/DTOs/PoseAnimator/PoseAnimatorDto.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/DTOs/PoseAnimator/PoseAnimatorDto.cs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using umi3d.common.userCapture.description;
+
 namespace umi3d.common.userCapture.pose
 {
     /// <summary>
@@ -26,6 +28,16 @@ namespace umi3d.common.userCapture.pose
         /// Id the corresponding node in the scene
         /// </summary>
         public ulong poseClipId { get; set; }
+
+        /// <summary>
+        /// True if the pose to play has an anchor.
+        /// </summary>
+        public bool isAnchored { get; set; }
+
+        /// <summary>
+        /// Constraints applied to override the default pose anchor.
+        /// </summary>
+        public PoseAnchorDto anchor { get; set; }
 
         /// <summary>
         /// Id the corresponding node in the scene

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/PoseData/UMI3DPoseResource.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/PoseData/UMI3DPoseResource.cs
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 - 2023 Inetum
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using umi3d.common.userCapture.description;
+using UnityEngine;
+
+namespace umi3d.common.userCapture.pose
+{
+    public class UMI3DPoseResource : IUMI3DPoseData
+    {
+        public PoseAnchorDto Anchor => anchor;
+        private PoseAnchorDto anchor;
+
+        public IList<BoneDto> Bones => bones;
+        private IList<BoneDto> bones;
+
+        public UMI3DPoseResource(UMI3DPose_so pose_so)
+        {
+            anchor = pose_so.Anchor;
+            bones = pose_so.Bones;
+        }
+
+        public PoseDto ToPoseDto()
+        {
+            return new PoseDto() { bones = new List<BoneDto>(), anchor = new PoseAnchorDto() };
+        }
+
+        public PoseDto ToPoseDto(PoseAnchoringType anchoringType, ulong poseRelativeNodeId, uint poseRelativeBone, Vector3 posOffset, Quaternion rotOffset)
+        {
+            PoseAnchorDto newAnchor;
+
+            switch (anchoringType)
+            {
+                case PoseAnchoringType.Node:
+                    newAnchor = new NodePoseAnchorDto() { bone = Anchor.bone, position = posOffset.Dto(), rotation = rotOffset.Dto(), node = poseRelativeNodeId };
+                    break;
+
+                case PoseAnchoringType.Bone:
+                    newAnchor = new BonePoseAnchorDto() { bone = Anchor.bone, position = posOffset.Dto(), rotation = rotOffset.Dto(), otherBone = poseRelativeBone };
+                    break;
+
+                case PoseAnchoringType.Floor:
+                    newAnchor = new FloorPoseAnchorDto() { bone = Anchor.bone, position = posOffset.Dto(), rotation = rotOffset.Dto() };
+                    break;
+
+                default:
+                    throw new System.Exception("AnchoringType not supported.");
+            }
+
+            return new PoseDto { bones = bones.ToList(), anchor = newAnchor };
+        }
+    }
+}

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/PoseData/UMI3DPoseResource.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/PoseData/UMI3DPoseResource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d56f9df9fb76ccd44ac7e738cdd78964
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/PoseData/UMI3DPose_so.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/PoseData/UMI3DPose_so.cs
@@ -26,7 +26,7 @@ namespace umi3d.common.userCapture.pose
     /// <summary>
     /// Scriptable object to contains data for a pose.
     /// </summary>
-    [Serializable, CreateAssetMenu(menuName ="UMI3D/UserCapture/Pose")]
+    [Serializable, CreateAssetMenu(menuName = "UMI3D/UserCapture/Pose")]
     public class UMI3DPose_so : ScriptableObject, IJsonSerializer, IUMI3DPoseData
     {
         #region Fields
@@ -46,7 +46,7 @@ namespace umi3d.common.userCapture.pose
         #endregion Fields
 
         /// <inheritdoc/>
-        public IList<BoneDto> Bones => bones.Select(b=>b.ToDto()).ToList();
+        public IList<BoneDto> Bones => bones.Select(b => b.ToDto()).ToList();
 
         /// <inheritdoc/>
         public PoseAnchorDto Anchor => boneAnchor.ToDto();
@@ -75,6 +75,11 @@ namespace umi3d.common.userCapture.pose
         public PoseDto ToPoseDto()
         {
             return new PoseDto() { bones = GetBonesCopy(), anchor = GetBonePoseCopy() };
+        }
+
+        public PoseDto ToPoseDto(PoseAnchoringType anchoringType, ulong poseRelativeNodeId, uint poseRelativeBone, Vector3 posOffset, Quaternion rotOffset)
+        {
+            return new PoseDto { bones = GetBonesCopy(), anchor = GetBonePoseCopy() };
         }
 
         /// <inheritdoc/>

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/Serializers/PoseAnimationSerializerModule.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/Serializers/PoseAnimationSerializerModule.cs
@@ -51,7 +51,7 @@ namespace umi3d.common.userCapture.pose
 
                         if (readable)
                         {
-                            PoseClipDto poseDto = new ()
+                            PoseClipDto poseDto = new()
                             {
                                 id = id,
                                 pose = pose
@@ -65,8 +65,9 @@ namespace umi3d.common.userCapture.pose
                 case true when typeof(T) == typeof(PoseAnimatorDto):
                     {
                         readable = UMI3DSerializer.TryRead(container, out ulong id);
-                        readable = UMI3DSerializer.TryRead(container, out ulong poseId);
-                        readable = UMI3DSerializer.TryRead(container, out ulong relativeNodeId);
+                        readable &= UMI3DSerializer.TryRead(container, out ulong poseId);
+                        readable &= UMI3DSerializer.TryRead(container, out bool isAnchored);
+                        readable &= UMI3DSerializer.TryRead(container, out ulong relativeNodeId);
                         readable &= UMI3DSerializer.TryRead(container, out DurationDto durationDto);
                         readable &= UMI3DSerializer.TryRead(container, out bool interpolable);
                         readable &= UMI3DSerializer.TryRead(container, out ushort activationMode);
@@ -76,10 +77,11 @@ namespace umi3d.common.userCapture.pose
 
                         if (readable)
                         {
-                            PoseAnimatorDto poseOverriderDto = new ()
+                            PoseAnimatorDto poseOverriderDto = new()
                             {
                                 id = id,
                                 poseClipId = poseId,
+                                isAnchored = isAnchored,
                                 relatedNodeId = relativeNodeId,
                                 poseConditions = poseConditionDtos,
                                 duration = durationDto,
@@ -170,6 +172,7 @@ namespace umi3d.common.userCapture.pose
                 case PoseAnimatorDto poseOverriderDto:
                     bytable = UMI3DSerializer.Write(poseOverriderDto.id)
                         + UMI3DSerializer.Write(poseOverriderDto.poseClipId)
+                        + UMI3DSerializer.Write(poseOverriderDto.isAnchored)
                         + UMI3DSerializer.Write(poseOverriderDto.relatedNodeId)
                         + UMI3DSerializer.Write(poseOverriderDto.duration)
                         + UMI3DSerializer.Write(poseOverriderDto.isInterpolable)

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/UserCapture/Editor/UMI3DPoseAnimatorEditor.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/UserCapture/Editor/UMI3DPoseAnimatorEditor.cs
@@ -32,6 +32,10 @@ namespace umi3d.edk.userCapture.pose.editor
     public class UMI3DPoseAnimatorEditor : Editor
     {
         private SerializedProperty poseSOField;
+
+        private SerializedProperty isAnchoredField;
+        private SerializedProperty anchoringParametersField;
+
         private SerializedProperty durationField;
 
         private SerializedProperty interpolableField;
@@ -47,6 +51,10 @@ namespace umi3d.edk.userCapture.pose.editor
         protected virtual void OnEnable()
         {
             poseSOField = serializedObject.FindProperty("pose_so");
+
+            isAnchoredField = serializedObject.FindProperty("isAnchored");
+            anchoringParametersField = serializedObject.FindProperty("anchoringParameters");
+
             durationField = serializedObject.FindProperty("duration");
 
             interpolableField = serializedObject.FindProperty("interpolable");
@@ -60,6 +68,11 @@ namespace umi3d.edk.userCapture.pose.editor
         protected virtual void OnInspectorGUIInternal()
         {
             EditorGUILayout.PropertyField(poseSOField);
+
+            EditorGUILayout.PropertyField(isAnchoredField);
+            if (isAnchoredField.boolValue)
+                EditorGUILayout.PropertyField(anchoringParametersField);
+
             EditorGUILayout.PropertyField(durationField);
 
             EditorGUILayout.PropertyField(interpolableField);


### PR DESCRIPTION
Modifying PoseAnimatorDto Serializer

Moving AnchoringType enum

Refacto snapdata in EDK & first implement in CDK

Updating EDK PoseAnimator & PoseClip system

Creating UMI3DPoseResource as buffer of UMI3DPose_so Adding a field in PoseAnimation for UMI3DNode as reference for pose Updating PoseClip to create pose with adapted PoseAnchorDto

Introducing SimulatedTracker

Creating Multi Anchored Simulated Trackers

Implementing Trackers Replacement & Simulation Stop

Changing enum inheritance

Fixing snap & cleaning logs

Fix Editor mode UT

Prevent playing two times the same pose clip

Remove simulated tracker when anchoring is finished

Init anchoring offsetdata by default

Updating SDK 2.8

Put anchoring override in PoseAnimator instead of PoseClip

A poseClip is 1:1 with a pose while a pose animator is 1:1 with a node. Needed for node anchoring.

Fix editor and rename fields