### PR TITLE
Feature/us 8867 hips not static during animations

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Emotes/Objects/Emote.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Emotes/Objects/Emote.cs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using umi3d.common;
 using umi3d.common.collaboration.dto.emotes;
 using UnityEngine;
 
@@ -35,7 +36,7 @@ namespace umi3d.cdk.collaboration.emotes
         /// </summary>
         public virtual ulong AnimationId => dto.animationId;
 
-        public ulong environmentId;
+        public ulong environmentId = UMI3DGlobalID.EnvironmentId;
 
         /// <summary>
         /// Icon of the emote in the UI

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Emotes/Services/EmoteManager.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Emotes/Services/EmoteManager.cs
@@ -169,6 +169,7 @@ namespace umi3d.cdk.collaboration.emotes
                     {
                         available = emoteConfigDto.allAvailableByDefault || emoteDtoInConfig.available,
                         icon = DefaultIcon,
+                        environmentId = UMI3DGlobalID.EnvironmentId,
                         dto = emoteDtoInConfig
                     };
                     if (emoteDtoInConfig.iconResource is not null

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
@@ -154,7 +154,7 @@ namespace umi3d.cdk.userCapture
 
             //very naive : for now, we consider the tracked hips as the computer hips
             Bones[BoneType.Hips].Position = HipsAnchor != null ? HipsAnchor.position : Vector3.zero;
-            Bones[BoneType.Hips].Rotation = HipsAnchor != null ? HipsAnchor.rotation : Quaternion.identity;
+            Bones[BoneType.Hips].Rotation = HipsAnchor != null ? HipsAnchor.rotation * Bones[BoneType.Hips].LocalRotation : Quaternion.identity;
 
             alreadyComputedBonesCache[BoneType.Hips] = true;
 
@@ -224,10 +224,7 @@ namespace umi3d.cdk.userCapture
 
                     foreach (var b in bones)
                     {
-                        if (b.boneType == BoneType.Hips)
-                            continue;
                         // if a bone rotation has already been registered, erase it
-
                         if (Bones.ContainsKey(b.boneType))
                             Bones[b.boneType].LocalRotation = b.localRotation.Quaternion();
                         else

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
@@ -162,30 +162,30 @@ namespace umi3d.cdk.userCapture
             foreach (uint boneType in Bones.Keys)
             {
                 if (!alreadyComputedBonesCache[boneType])
-                    ComputeBonePosition(boneType);
+                    ComputeBoneTransform(boneType);
             }
 
             return this;
         }
 
         /// <summary>
-        /// Cache for bottom-up recursive <see cref="ComputeBonePosition(uint)"/> method.
+        /// Cache for bottom-up recursive <see cref="ComputeBoneTransform(uint)"/> method.
         /// Speeding up computations.
         /// </summary>
         private Dictionary<uint, bool> alreadyComputedBonesCache = new();
 
         /// <summary>
-        /// Compute the final position of each bone, and their parents recursively if not already computed
+        /// Compute the final position and rotation of each bone, and their parents recursively if not already computed
         /// </summary>
         /// <param name="boneType"></param>
-        private void ComputeBonePosition(uint boneType)
+        private void ComputeBoneTransform(uint boneType)
         {
             if (!alreadyComputedBonesCache[boneType]
                 && SkeletonHierarchy.Relations.TryGetValue(boneType, out var boneRelation)
                 && boneRelation.boneTypeParent != BoneType.None)
             {
                 if (!alreadyComputedBonesCache[boneRelation.boneTypeParent])
-                    ComputeBonePosition(boneRelation.boneTypeParent);
+                    ComputeBoneTransform(boneRelation.boneTypeParent);
 
                 Matrix4x4 m = Matrix4x4.TRS(Bones[boneRelation.boneTypeParent].Position, Bones[boneRelation.boneTypeParent].Rotation, transform.localScale * (1f/SKELETON_STANDARD_SIZE));
                 Bones[boneType].Position = m.MultiplyPoint3x4(boneRelation.relativePosition); //Bones[boneRelation.boneTypeParent].Position + Bones[boneRelation.boneTypeParent].Rotation * boneRelation.relativePosition;

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
@@ -102,6 +102,8 @@ namespace umi3d.cdk.userCapture
         [SerializeField, Tooltip("Anchor of the skeleton hierarchy.")]
         protected Transform hipsAnchor;
 
+        private const float SKELETON_STANDARD_SIZE = 1.8f;
+
         #endregion Fields
 
         public void Init(ITrackedSubskeleton trackedSkeleton, IPoseSubskeleton poseSkeleton)
@@ -185,7 +187,7 @@ namespace umi3d.cdk.userCapture
                 if (!alreadyComputedBonesCache[boneRelation.boneTypeParent])
                     ComputeBonePosition(boneRelation.boneTypeParent);
 
-                Matrix4x4 m = Matrix4x4.TRS(Bones[boneRelation.boneTypeParent].Position, Bones[boneRelation.boneTypeParent].Rotation, transform.localScale * (1f/1.8f));
+                Matrix4x4 m = Matrix4x4.TRS(Bones[boneRelation.boneTypeParent].Position, Bones[boneRelation.boneTypeParent].Rotation, transform.localScale * (1f/SKELETON_STANDARD_SIZE));
                 Bones[boneType].Position = m.MultiplyPoint3x4(boneRelation.relativePosition); //Bones[boneRelation.boneTypeParent].Position + Bones[boneRelation.boneTypeParent].Rotation * boneRelation.relativePosition;
                 Bones[boneType].Rotation = (Bones[boneRelation.boneTypeParent].Rotation * Bones[boneType].LocalRotation).normalized;
                 alreadyComputedBonesCache[boneType] = true;

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Animation/Loader/SkeletonAnimationNodeLoader.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Animation/Loader/SkeletonAnimationNodeLoader.cs
@@ -114,6 +114,9 @@ namespace umi3d.cdk.userCapture.animation
             foreach (var renderer in nodeInstance.gameObject.GetComponentsInChildren<Renderer>())
                 renderer.gameObject.layer = LayerMask.NameToLayer("Invisible");
 
+            // scale the subskeleton to fit the scale of the user
+            nodeInstance.transform.localScale = personnalSkeletonService.PersonalSkeleton.worldSize;
+
             _ = Task.Run(async () => // task is required to load asynchronously while not blocking the loading process
             {
                 // get animation related to the skeleton node

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Description/SkeletonMapping/SkeletonMapper.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Description/SkeletonMapping/SkeletonMapper.cs
@@ -44,7 +44,8 @@ namespace umi3d.common.userCapture.description
         {
             get
             {
-                if (boneAnchor == null && anchor != null)
+                if ((boneAnchor == null && anchor != null) 
+                    || boneAnchor.position.Struct() != anchor.transform.position)
                 {
                     boneAnchor = new PoseAnchorDto()
                     {


### PR DESCRIPTION
This PR adresses the issue that Hips is statis during skeletons animations. It now takes into account the Hips rotation and translation during animations.