### PR TITLE
Add pose interpolation

### DIFF
--- a/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Pose/Loader/PoseAnimatorLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Pose/Loader/PoseAnimatorLoader_Test.cs
@@ -178,8 +178,6 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
             Assert.AreEqual(dto.poseClipId, poseAnimator.PoseClip.Id);
             Assert.AreEqual(dto.relatedNodeId, poseAnimator.RelativeNodeId);
             Assert.AreEqual(dto.duration, poseAnimator.Duration);
-            Assert.AreEqual(dto.isComposable, poseAnimator.IsComposable);
-            Assert.AreEqual(dto.isInterpolable, poseAnimator.IsInterpolable);
             Assert.AreEqual(dto.activationMode, poseAnimator.ActivationMode);
             Assert.AreEqual(dto.poseConditions.Length, poseAnimator.PoseConditions.Length);
         }

--- a/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Pose/PoseSubskeleton_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Pose/PoseSubskeleton_Test.cs
@@ -21,7 +21,9 @@ using System.Collections.Generic;
 using System.Linq;
 using TestUtils.UserCapture;
 using umi3d.cdk;
+using umi3d.cdk.userCapture;
 using umi3d.cdk.userCapture.pose;
+using umi3d.cdk.userCapture.tracking;
 using umi3d.common.userCapture;
 using umi3d.common.userCapture.description;
 using umi3d.common.userCapture.pose;
@@ -37,6 +39,7 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
         private PoseSubskeleton poseSubskeleton = null;
 
         private Mock<IEnvironmentManager> environmentServiceMock;
+        private Mock<ISkeleton> parentSkeletonMock;
 
         #region SetUp
 
@@ -50,7 +53,8 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
         public void SetUp()
         {
             environmentServiceMock = new();
-            poseSubskeleton = new PoseSubskeleton(0,environmentServiceMock.Object);
+            parentSkeletonMock = new();
+            poseSubskeleton = new PoseSubskeleton(0, parentSkeletonMock.Object, environmentServiceMock.Object);
         }
 
         [TearDown]
@@ -100,7 +104,7 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
         public void StartPose_One()
         {
             // GIVEN
-            var pose = new PoseClip(new());
+            var pose = new PoseClip(new() { pose = new() });
 
             // WHEN
             poseSubskeleton.StartPose(pose, true);
@@ -116,8 +120,8 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
             // GIVEN
             var poses = new List<PoseClip>()
             {
-                new (new ()),
-                new (new ()),
+                new (new () { pose = new() }),
+                new (new () { pose = new() }),
             };
 
             // WHEN
@@ -161,7 +165,7 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
         public void StopPose_One()
         {
             // GIVEN
-            var pose = new PoseClip(new());
+            var pose = new PoseClip(new() { pose = new() });
 
             poseSubskeleton.StartPose(pose, true);
 
@@ -178,9 +182,9 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
             // GIVEN
             var poses = new List<PoseClip>()
             {
-                new (new ()),
-                new (new ()),
-                new (new ()),
+                new (new () { pose = new() }),
+                new (new () { pose = new() }),
+                new (new () { pose = new() }),
             };
 
             var posesToStop = poses.ToArray()[0..2];
@@ -204,8 +208,8 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
             // GIVEN
             var poses = new List<PoseClip>()
             {
-                new (new ()),
-                new (new ()),
+                new (new () { pose = new() }),
+                new (new () { pose = new() }),
             };
 
             poseSubskeleton.StartPose(poses, false);
@@ -338,6 +342,9 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
                 new (new () { id=1006uL, pose = new() { bones=new() { new() { boneType=BoneType.Chest } }, anchor=new()} }),
             };
 
+            Mock<ITrackedSubskeleton> trackedSubskeletonMock = new ();
+            parentSkeletonMock.Setup(x => x.TrackedSubskeleton).Returns(trackedSubskeletonMock.Object);
+            trackedSubskeletonMock.Setup(x => x.StartTrackerSimulation(It.IsAny<PoseAnchorDto>()));
             environmentServiceMock.Setup(x => x.TryGetEntityInstance(0, poseClips[0].Id)).Returns(new UMI3DEntityInstance(0, () => { }, 0) { Object=poseClips[0] });
             environmentServiceMock.Setup(x => x.TryGetEntityInstance(0, poseClips[1].Id)).Returns(new UMI3DEntityInstance(0, () => { }, 0) { Object = poseClips[1] });
 
@@ -384,6 +391,9 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
                 new (new () { id=1, pose = new() { bones=new() { new() { boneType=BoneType.Chest } }, anchor=new()} }),
             };
 
+            Mock<ITrackedSubskeleton> trackedSubskeletonMock = new();
+            parentSkeletonMock.Setup(x => x.TrackedSubskeleton).Returns(trackedSubskeletonMock.Object);
+            trackedSubskeletonMock.Setup(x => x.StartTrackerSimulation(It.IsAny<PoseAnchorDto>()));
             poseSubskeleton.StartPose(poses, true);
 
             UserTrackingFrameDto frame = new();

--- a/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Pose/Services/PoseManager_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Pose/Services/PoseManager_Test.cs
@@ -78,7 +78,7 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
             var poseSubskeletonMock = new Mock<IPoseSubskeleton>();
             skeletonManagerServiceMock.Setup(x => x.PersonalSkeleton).Returns(personalSkeletonMock.Object);
             personalSkeletonMock.Setup(x => x.PoseSubskeleton).Returns(poseSubskeletonMock.Object);
-            poseSubskeletonMock.Setup(x => x.StartPose(It.IsAny<PoseClip>(), false));
+            poseSubskeletonMock.Setup(x => x.StartPose(It.IsAny<PoseClip>(), false, It.IsAny<PosePlayer.PlayingParameters>()));
             // When
             bool result = false;
             TestDelegate action = () => result = poseManager.TryActivatePoseAnimator(UMI3DGlobalID.EnvironmentId, dto.id);
@@ -122,7 +122,7 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
             skeletonManagerServiceMock.Setup(x => x.PersonalSkeleton).Returns(personalSkeletonMock.Object);
             personalSkeletonMock.Setup(x => x.PoseSubskeleton).Returns(poseSubskeletonMock.Object);
             poseSubskeletonMock.Setup(x => x.AppliedPoses).Returns(new List<PoseClip>());
-            poseSubskeletonMock.Setup(x => x.StartPose(It.IsAny<PoseClip>(), false));
+            poseSubskeletonMock.Setup(x => x.StartPose(It.IsAny<PoseClip>(), false, It.IsAny<PosePlayer.PlayingParameters>()));
             personalSkeletonMock.Setup(x => x.TrackedSubskeleton).Returns(trackedSubskeletonMock.Object);
             trackedSubskeletonMock.Setup(x => x.StartTrackerSimulation(It.IsAny<PoseAnchorDto>()));
 
@@ -130,7 +130,7 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
             poseManager.PlayPoseClip(poseClip);
 
             // Then
-            poseSubskeletonMock.Verify(x => x.StartPose(It.IsAny<PoseClip>(), false), Times.Once());
+            poseSubskeletonMock.Verify(x => x.StartPose(It.IsAny<PoseClip>(), false, It.IsAny<PosePlayer.PlayingParameters>()), Times.Once());
             trackedSubskeletonMock.Verify(x => x.StartTrackerSimulation(It.IsAny<PoseAnchorDto>()), Times.Never());
         }
 
@@ -155,7 +155,7 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
             skeletonManagerServiceMock.Setup(x => x.PersonalSkeleton).Returns(personalSkeletonMock.Object);
             personalSkeletonMock.Setup(x => x.PoseSubskeleton).Returns(poseSubskeletonMock.Object);
             poseSubskeletonMock.Setup(x => x.AppliedPoses).Returns(new List<PoseClip>());
-            poseSubskeletonMock.Setup(x => x.StartPose(It.IsAny<PoseClip>(), false));
+            poseSubskeletonMock.Setup(x => x.StartPose(It.IsAny<PoseClip>(), false, It.IsAny<PosePlayer.PlayingParameters>()));
             personalSkeletonMock.Setup(x => x.TrackedSubskeleton).Returns(trackedSubskeletonMock.Object);
             trackedSubskeletonMock.Setup(x => x.StartTrackerSimulation(It.IsAny<PoseAnchorDto>()));
 
@@ -163,7 +163,7 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
             poseManager.PlayPoseClip(poseClip);
 
             // Then
-            poseSubskeletonMock.Verify(x => x.StartPose(It.IsAny<PoseClip>(), false), Times.Once());
+            poseSubskeletonMock.Verify(x => x.StartPose(It.IsAny<PoseClip>(), false, It.IsAny<PosePlayer.PlayingParameters>()), Times.Once());
             trackedSubskeletonMock.Verify(x => x.StartTrackerSimulation(It.IsAny<PoseAnchorDto>()), Times.Once());
         }
 
@@ -184,16 +184,16 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
             skeletonManagerServiceMock.Setup(x => x.PersonalSkeleton).Returns(personalSkeletonMock.Object);
             personalSkeletonMock.Setup(x => x.PoseSubskeleton).Returns(poseSubskeletonMock.Object);
             poseSubskeletonMock.Setup(x => x.AppliedPoses).Returns(new List<PoseClip>());
-            poseSubskeletonMock.Setup(x => x.StartPose(It.IsAny<PoseClip>(), false));
+            poseSubskeletonMock.Setup(x => x.StartPose(It.IsAny<PoseClip>(), false, It.IsAny<PosePlayer.PlayingParameters>()));
             personalSkeletonMock.Setup(x => x.TrackedSubskeleton).Returns(trackedSubskeletonMock.Object);
             trackedSubskeletonMock.Setup(x => x.StartTrackerSimulation(It.IsAny<PoseAnchorDto>()));
 
             PoseAnchorDto anchorDto = new();
             // When
-            poseManager.PlayPoseClip(poseClip, anchorDto);
+            poseManager.PlayPoseClip(poseClip, new PosePlayer.PlayingParameters() { isAnchored = true, anchor = anchorDto });
 
             // Then
-            poseSubskeletonMock.Verify(x => x.StartPose(It.IsAny<PoseClip>(), false), Times.Once());
+            poseSubskeletonMock.Verify(x => x.StartPose(It.IsAny<PoseClip>(), false, It.IsAny<PosePlayer.PlayingParameters>()), Times.Once());
             trackedSubskeletonMock.Verify(x => x.StartTrackerSimulation(It.IsAny<PoseAnchorDto>()), Times.Once());
         }
 
@@ -213,13 +213,13 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
             skeletonManagerServiceMock.Setup(x => x.PersonalSkeleton).Returns(personalSkeletonMock.Object);
             personalSkeletonMock.Setup(x => x.PoseSubskeleton).Returns(poseSubskeletonMock.Object);
             poseSubskeletonMock.Setup(x => x.AppliedPoses).Returns(new List<PoseClip>() { poseClip });
-            poseSubskeletonMock.Setup(x => x.StartPose(It.IsAny<PoseClip>(), false));
+            poseSubskeletonMock.Setup(x => x.StartPose(It.IsAny<PoseClip>(), false, It.IsAny<PosePlayer.PlayingParameters>()));
 
             // When
             poseManager.PlayPoseClip(poseClip);
 
             // Then
-            poseSubskeletonMock.Verify(x => x.StartPose(It.IsAny<PoseClip>(), false), Times.Never());
+            poseSubskeletonMock.Verify(x => x.StartPose(It.IsAny<PoseClip>(), false, It.IsAny<PosePlayer.PlayingParameters>()), Times.Never());
         }
 
         #endregion PlayPoseClip

--- a/UMI3D-SDK/Assets/Tests/EditMode_Tests/Common/UserCapture/Pose/Serializer/PoseAnimationSerializerModule_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/EditMode_Tests/Common/UserCapture/Pose/Serializer/PoseAnimationSerializerModule_Test.cs
@@ -103,8 +103,6 @@ namespace EditMode_Tests.UserCapture.Pose.Common
                     new DirectionConditionDto() { Direction = Vector3.one.Dto() },
                 },
                 duration = new DurationDto() { duration = 24, max = 12, min = 2 },
-                isInterpolable = true,
-                isComposable = false,
                 activationMode = 0,
             };
 
@@ -121,8 +119,6 @@ namespace EditMode_Tests.UserCapture.Pose.Common
 
 
             Assert.AreEqual(poseAnimatorDto.duration.duration, result.duration.duration);
-            Assert.AreEqual(poseAnimatorDto.isInterpolable, result.isInterpolable);
-            Assert.AreEqual(poseAnimatorDto.isComposable, result.isComposable);
 
             Assert.AreEqual(poseAnimatorDto.activationMode, result.activationMode);
 

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/Skeletons/CollaborationSkeletonsManager_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/Skeletons/CollaborationSkeletonsManager_Test.cs
@@ -578,7 +578,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.CDK
             collaborativeSkeletonManager.ApplyPoseRequest(UMI3DGlobalID.EnvironmentId,playPoseDto);
 
             // then
-            poseSkeletonMock.Setup(x => x.StartPose(It.IsAny<PoseClip>(), It.IsAny<bool>()));
+            poseSkeletonMock.Setup(x => x.StartPose(It.IsAny<PoseClip>(), It.IsAny<bool>(), It.IsAny<PosePlayer.PlayingParameters>()));
         }
 
         [Test]

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/UserCapture/CollaborationSkeletonsManager.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/UserCapture/CollaborationSkeletonsManager.cs
@@ -223,7 +223,7 @@ namespace umi3d.cdk.collaboration.userCapture
             var trackedSkeleton = UnityEngine.Object.Instantiate(trackedSkeletonPrefab, cs.transform).GetComponent<TrackedSubskeleton>();
             trackedSkeleton.EnvironmentId = environmentId;
 
-            var poseSkeleton = new PoseSubskeleton(environmentId);
+            var poseSkeleton = new PoseSubskeleton(environmentId, parentSkeleton: cs, environmentManagerService: collaborativeEnvironmentManagementService);
 
             cs.Init(trackedSkeleton, poseSkeleton);
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/PersonalSkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/PersonalSkeleton.cs
@@ -39,7 +39,7 @@ namespace umi3d.cdk.userCapture
 
         protected void Start()
         {
-            PoseSubskeleton = new PoseSubskeleton(UMI3DGlobalID.EnvironmentId);
+            PoseSubskeleton = new PoseSubskeleton(UMI3DGlobalID.EnvironmentId, this);
 
             //Init(trackedSkeleton, PoseSubskeleton);
         }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/IPoseSubskeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/IPoseSubskeleton.cs
@@ -23,8 +23,6 @@ namespace umi3d.cdk.userCapture.pose
     /// </summary>
     public interface IPoseSubskeleton : IWritableSubskeleton
     {
-
-
         /// <summary>
         /// List of poses that are currently applied on the subskeleton.
         /// </summary>
@@ -35,14 +33,14 @@ namespace umi3d.cdk.userCapture.pose
         /// </summary>
         /// <param name="posesToAdd">Poses to start to apply</param>
         /// <param name="isOverriding">If true, all previous poses will be stopped.</param>
-        void StartPose(IEnumerable<PoseClip> posesToAdd, bool isOverriding = false);
+        void StartPose(IEnumerable<PoseClip> posesToAdd, bool isOverriding = false, PosePlayer.PlayingParameters parameters = null);
 
         /// <summary>
         /// Set a pose for the calculation of the next tracking frame
         /// </summary>
         /// <param name="posesToAdd">Poses to start to apply</param>
         /// <param name="isOverriding">If true, all previous poses will be stopped.</param>
-        void StartPose(PoseClip poseToAdd, bool isOverriding = false);
+        void StartPose(PoseClip poseToAdd, bool isOverriding = false, PosePlayer.PlayingParameters parameters = null);
 
         /// <summary>
         /// Remove all poses from computation.

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Loader/PoseAnimatorLoader.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Loader/PoseAnimatorLoader.cs
@@ -29,7 +29,7 @@ namespace umi3d.cdk.userCapture.pose
     {
         private const DebugScope DEBUG_SCOPE = DebugScope.CDK | DebugScope.UserCapture | DebugScope.Loading;
 
-        private static readonly UMI3DVersion.VersionCompatibility _version = new UMI3DVersion.VersionCompatibility("2.7", "*");
+        private static readonly UMI3DVersion.VersionCompatibility _version = new UMI3DVersion.VersionCompatibility("2.8", "*");
         public override UMI3DVersion.VersionCompatibility version => _version;
 
         #region Dependencies Injection
@@ -69,7 +69,8 @@ namespace umi3d.cdk.userCapture.pose
             UMI3DEntityInstance poseClipInstance = await loadingService.WaitUntilEntityLoaded(environmentId, dto.poseClipId, null);
             PoseClip poseClip = (PoseClip)poseClipInstance.Object;
 
-            PoseAnimator poseAnimator = new(dto, poseClip, poseConditions.Where(x => x is not null).ToArray());
+            PoseAnimator poseAnimator = new PoseAnimator(dto, poseClip, poseConditions.Where(x => x is not null).ToArray());
+
 
             if (poseAnimator.ActivationMode == (ushort)PoseAnimatorActivationMode.AUTO)
                 poseAnimator.StartWatchActivationConditions();

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PoseAnimator/IPoseAnimator.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PoseAnimator/IPoseAnimator.cs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 using System;
+using umi3d.common.userCapture.description;
 
 namespace umi3d.cdk.userCapture.pose
 {

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PoseAnimator/PoseAnimator.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PoseAnimator/PoseAnimator.cs
@@ -17,6 +17,8 @@ limitations under the License.
 using inetum.unityUtils;
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using umi3d.common.userCapture;
 using umi3d.common.userCapture.description;
 using umi3d.common.userCapture.pose;
 using UnityEngine;
@@ -67,16 +69,6 @@ namespace umi3d.cdk.userCapture.pose
         /// How long the pose should last [Not Implemented]
         /// </summary>
         public DurationDto Duration => dto.duration;
-
-        /// <summary>
-        /// If the pose can be interpolated
-        /// </summary>
-        public bool IsInterpolable => dto.isInterpolable;
-
-        /// <summary>
-        /// If the pose can be added to  other poses
-        /// </summary>
-        public bool IsComposable => dto.isComposable;
 
         /// <summary>
         /// How the pose is activated.
@@ -197,7 +189,11 @@ namespace umi3d.cdk.userCapture.pose
         private void Apply()
         {
             IsApplied = true;
-            poseService.PlayPoseClip(poseClip, Anchor);
+            poseService.PlayPoseClip(poseClip, new PosePlayer.PlayingParameters()
+            {
+                isAnchored = Anchor != null,
+                anchor = Anchor
+            });
             ConditionsValidated?.Invoke();
             StartWatchEndOfConditions();
         }
@@ -308,5 +304,7 @@ namespace umi3d.cdk.userCapture.pose
 
             return false;
         }
+
+        
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PoseClip.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PoseClip.cs
@@ -39,6 +39,16 @@ namespace umi3d.cdk.userCapture.pose
         public List<BoneDto> Bones => dto.pose.bones;
 
         /// <summary>
+        /// See <see cref="PoseClipDto.isComposable"/>.
+        /// </summary>
+        public bool IsComposable => dto.isComposable;
+
+        /// <summary>
+        /// See <see cref="PoseClipDto.isInterpolable"/>.
+        /// </summary>
+        public bool IsInterpolable => dto.isInterpolable;
+
+        /// <summary>
         /// Description of the pose animation.
         /// </summary>
         public PoseDto Pose => dto.pose;

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PosePlayer.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PosePlayer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 764e7a4c7f93983439aa985af456fcbb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PosePlayer/IPosePlayer.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PosePlayer/IPosePlayer.cs
@@ -1,0 +1,68 @@
+﻿/*
+Copyright 2019 - 2024 Inetum
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+using umi3d.common.userCapture.description;
+
+namespace umi3d.cdk.userCapture.pose
+{
+    /// <summary>
+    /// Player that applies a pose and gives the values corresponding to it. Ensure the interpolation if needed.
+    /// </summary>
+    public interface IPosePlayer
+    {
+        /// <summary>
+        /// Pose clip handled by the player.
+        /// </summary>
+        PoseClip PoseClip { get; }
+
+        /// <summary>
+        /// True if the player is currently applying a pose.
+        /// </summary>
+        /// Note that this value is still true after some time 
+        /// after calling <see cref="EndPoseClip(bool)"/> because of end of application handling.
+        bool IsPlaying { get; }
+
+        /// <summary>
+        /// True when the player is in the ending interpolation phase.
+        /// </summary>
+        bool IsEnding { get; }
+
+        /// <summary>
+        /// Complete skeleton affected by the player.
+        /// </summary>
+        ISkeleton Skeleton { get; }
+
+        /// <summary>
+        /// Start to apply a pose on the affected skeleton.
+        /// </summary>
+        /// <param name="parameters">Optional parameters to control the pose playing.</param>
+        void PlayPoseClip(PosePlayer.PlayingParameters parameters = null);
+
+        /// <summary>
+        /// Start to end a pose on the affected skeleton. 
+        /// </summary>
+        /// <param name="shouldStopImmediate">If true, the pose is ended immediately with no ending inteprolation phase.</param>
+        void EndPoseClip(bool shouldStopImmediate = false);
+
+        /// <summary>
+        /// Get the output pose from the player.
+        /// </summary>
+        /// <param name="hierarchy"></param>
+        /// <returns></returns>
+        SubSkeletonPoseDto GetPose(UMI3DSkeletonHierarchy hierarchy);
+    }
+}

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PosePlayer/IPosePlayer.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PosePlayer/IPosePlayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4e257787c8f26be42aede426f5d214b0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PosePlayer/PosePlayer.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PosePlayer/PosePlayer.cs
@@ -1,0 +1,267 @@
+﻿/*
+Copyright 2019 - 2024 Inetum
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+using inetum.unityUtils;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+using umi3d.common.userCapture;
+using umi3d.common.userCapture.description;
+using UnityEngine;
+
+namespace umi3d.cdk.userCapture.pose
+{
+    /// <summary>
+    /// Player that applies a pose and gives the values corresponding to it. Ensure the interpolation if needed.
+    /// </summary>
+    public class PosePlayer : IPosePlayer
+    {
+        /// <summary>
+        /// Pose clip handled by the player.
+        /// </summary>
+        public PoseClip PoseClip { get; private set; }
+
+        /// <summary>
+        /// Complete skeleton affected by the player.
+        /// </summary>
+        public ISkeleton Skeleton { get; private set; }
+
+        /// <summary>
+        /// True if the player is currently applying a pose.
+        /// </summary>
+        /// Note that this value is still true after some time 
+        /// after calling <see cref="EndPoseClip(bool)"/> because of end of application handling.
+        public bool IsPlaying { get; private set; } = false;
+
+        /// <summary>
+        /// True when the player is in the ending interpolation phase.
+        /// </summary>
+        public bool IsEnding { get; private set; } = false;
+
+        protected PosePlayingData playingData;
+
+        /// <summary>
+        /// Parameters used to request a specific application of the pose.
+        /// </summary>
+        public class PlayingParameters
+        {
+            /// <summary>
+            /// True if pose is meant to be anchored.
+            /// </summary>
+            public bool isAnchored;
+
+            /// <summary>
+            /// Specified anchor when pose is anchored.
+            /// </summary>
+            public PoseAnchorDto anchor;
+
+            /// <summary>
+            /// Duration (in seconds) of the transition when pose is starting to be applied.
+            /// </summary>
+            public float startTransitionDuration = 0.25f;
+
+            /// <summary>
+            /// Duration (in seconds) of the transition when pose is ending to be applied.
+            /// </summary>
+            public float endTransitionDuration = 0.25f;
+        }
+
+        protected struct PosePlayingData
+        {
+            public readonly float startTime;
+            public readonly PlayingParameters parameters;
+            public float endAskedTime;
+
+            public PosePlayingData(float startTime, PlayingParameters parameters)
+            {
+                this.startTime = startTime;
+                this.parameters = parameters;
+                endAskedTime = -1f;
+            }
+        }
+
+        #region DI
+
+        private readonly ICoroutineService coroutineService;
+
+        public PosePlayer(PoseClip poseClip, ISkeleton parentSkeleton, ICoroutineService coroutineService)
+        {
+            PoseClip = poseClip ?? throw new System.ArgumentNullException(nameof(PoseClip));
+            this.Skeleton = parentSkeleton ?? throw new System.ArgumentNullException(nameof(parentSkeleton));
+            this.coroutineService = coroutineService;
+        }
+
+        public PosePlayer(PoseClip poseClip, ISkeleton parentSkeleton) : this(poseClip, parentSkeleton, CoroutineManager.Instance)
+        {
+        }
+
+        #endregion DI
+
+        /// <inheritdoc/>
+        public void PlayPoseClip(PlayingParameters parameters = null)
+        {
+            if (IsPlaying)
+                return;
+
+            IsPlaying = true;
+
+            playingData = new(UnityEngine.Time.time, parameters ?? new());
+
+            if (!playingData.parameters.isAnchored && PoseClip.Pose.anchor != null)
+            {
+                playingData.parameters.isAnchored = true;
+                playingData.parameters.anchor = PoseClip.Pose.anchor;
+            }
+
+            if (playingData.parameters.isAnchored)
+                Skeleton.TrackedSubskeleton.StartTrackerSimulation(playingData.parameters.anchor);
+        }
+
+        /// <inheritdoc/>
+        public void EndPoseClip(bool shouldStopImmediate = false)
+        {
+            if (!IsPlaying)
+                return;
+
+            if (!shouldStopImmediate && PoseClip.IsInterpolable)
+            {
+                IsEnding = true;
+                playingData.endAskedTime = Time.time;
+                endPoseClipRoutine = coroutineService.AttachCoroutine(EndPoseClipRoutine());
+            }
+            else
+            {
+                if (IsEnding) // force end while ending
+                {
+                    IsEnding = false;
+                    coroutineService.DetachCoroutine(endPoseClipRoutine);
+                    endPoseClipRoutine = null;
+                }
+                StopPoseClip();
+            }
+        }
+
+        private Coroutine endPoseClipRoutine;
+
+        /// <summary>
+        /// Coroutine handling the waiting for the ending phase.
+        /// </summary>
+        /// <returns></returns>
+        private IEnumerator EndPoseClipRoutine()
+        {
+            yield return new WaitForSeconds(playingData.parameters.endTransitionDuration);
+            IsEnding = false;
+            StopPoseClip();
+            coroutineService.DetachCoroutine(endPoseClipRoutine);
+            endPoseClipRoutine = null;
+        }
+
+        private void StopPoseClip()
+        {
+            if (playingData.parameters.isAnchored)
+                Skeleton.TrackedSubskeleton.StopTrackerSimulation(playingData.parameters.anchor);
+
+            IsPlaying = false;
+            playingData = default;
+        }
+
+        /// <inheritdoc/>
+        public SubSkeletonPoseDto GetPose(UMI3DSkeletonHierarchy hierarchy)
+        {
+            if (hierarchy == null)
+                throw new ArgumentNullException(nameof(hierarchy));
+
+            if (!IsPlaying)
+                return null;
+
+            Dictionary<uint, SubSkeletonBoneDto> bonePoses = new();
+
+            foreach (var bone in PoseClip.Bones)
+            {
+                SubSkeletonBoneDto bonePose = GetBonePose(hierarchy, bone, PoseClip).subBone;
+
+                if (PoseClip.IsInterpolable)
+                {
+                    if (!IsEnding)
+                        bonePose.localRotation = Quaternion.Slerp(Skeleton.Bones[bone.boneType].LocalRotation, bonePose.localRotation.Quaternion(), (Time.time - playingData.startTime) / playingData.parameters.startTransitionDuration).Dto();
+                    else
+                        bonePose.localRotation = Quaternion.Slerp(bonePose.localRotation.Quaternion(), Skeleton.Bones[bone.boneType].LocalRotation, (Time.time - playingData.endAskedTime) / playingData.parameters.endTransitionDuration).Dto();
+                }
+
+                bonePoses[bone.boneType] = bonePose;
+            }
+
+            computedMap.Clear();
+
+            return new SubSkeletonPoseDto()
+            {
+                bones = bonePoses.Values.ToList()
+            };
+        }
+
+        private Dictionary<uint, (BoneDto bone, SubSkeletonBoneDto subBone)> computedMap = new();
+
+        /// <summary>
+        /// Recursively compute local rotation for a bone.
+        /// </summary>
+        /// <param name="hierarchy"></param>
+        /// <param name="boneDto"></param>
+        /// <param name="pose"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        private (BoneDto bone, SubSkeletonBoneDto subBone) GetBonePose(UMI3DSkeletonHierarchy hierarchy, BoneDto boneDto, PoseClip pose)
+        {
+            if (boneDto == null)
+                throw new ArgumentNullException(nameof(boneDto));
+
+            uint boneType = boneDto.boneType;
+
+            if (computedMap.ContainsKey(boneType))
+                return computedMap[boneType];
+
+            if (!hierarchy.Relations.ContainsKey(boneType))
+                throw new ArgumentException($"Bone ({boneType}, \"{BoneTypeHelper.GetBoneName(boneType)}\") not defined in hierarchy.", nameof(boneDto));
+
+            var relation = hierarchy.Relations[boneType];
+
+            var parentBone = pose.Bones.Find(b => b.boneType == relation.boneTypeParent);
+
+            SubSkeletonBoneDto subBone = new() { boneType = boneType };
+            if (parentBone == default || parentBone.boneType == BoneType.None) // bone has no parent
+            {
+                subBone.localRotation = boneDto.rotation;
+            }
+            else // bone has a parent and thus its rotation depends on it
+            {
+                var parent = GetBonePose(hierarchy, parentBone, pose);
+                subBone.localRotation = (Quaternion.Inverse(parent.bone.rotation.Quaternion()) * boneDto.rotation.Quaternion()).Dto();
+            }
+
+            computedMap[boneType] = new()
+            {
+                bone = boneDto,
+                subBone = subBone
+            };
+
+            return computedMap[boneType];
+        }
+
+    }
+}

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PosePlayer/PosePlayer.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Objects/PosePlayer/PosePlayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8822bee18ba2e5548838cc3791f10a07
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Service/IPoseManager.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Service/IPoseManager.cs
@@ -26,8 +26,7 @@ namespace umi3d.cdk.userCapture.pose
         /// <summary>
         /// Sets the related pose in the poseSkeleton
         /// </summary>
-        /// <param name="poseClip"></param>
-        void PlayPoseClip(PoseClip poseClip, PoseAnchorDto poseAnchorDto = null);
+        void PlayPoseClip(PoseClip poseClip, PosePlayer.PlayingParameters parameters = null);
 
         /// <summary>
         /// Stops all poses

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Service/PoseManager.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/Service/PoseManager.cs
@@ -76,7 +76,7 @@ namespace umi3d.cdk.userCapture.pose
         }
 
         /// <inheritdoc/>
-        public void PlayPoseClip(PoseClip poseClip, PoseAnchorDto anchor = null)
+        public void PlayPoseClip(PoseClip poseClip, PosePlayer.PlayingParameters parameters = null)
         {
             if (poseClip == null)
                 throw new System.ArgumentNullException(nameof(poseClip));
@@ -84,14 +84,14 @@ namespace umi3d.cdk.userCapture.pose
             if (skeletonManager.PersonalSkeleton.PoseSubskeleton.AppliedPoses.Contains(poseClip))
                 return;
 
-            skeletonManager.PersonalSkeleton.PoseSubskeleton.StartPose(poseClip);
+            skeletonManager.PersonalSkeleton.PoseSubskeleton.StartPose(poseClip, parameters: parameters);
 
-            if (anchor != null)
-                skeletonManager.PersonalSkeleton.TrackedSubskeleton.StartTrackerSimulation(anchor);
+            if (parameters != null && parameters.isAnchored)
+                skeletonManager.PersonalSkeleton.TrackedSubskeleton.StartTrackerSimulation(parameters.anchor);
             else if (poseClip.Pose.anchor != null)
                 skeletonManager.PersonalSkeleton.TrackedSubskeleton.StartTrackerSimulation(poseClip.Pose.anchor);
             
-            anchoredPoseClips.Add(poseClip, anchor);
+            anchoredPoseClips.Add(poseClip, parameters?.anchor);
         }
 
         /// <inheritdoc/>

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/DTOs/Pose/PoseClipDto.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/DTOs/Pose/PoseClipDto.cs
@@ -27,5 +27,15 @@ namespace umi3d.common.userCapture.pose
         /// Pose description for the animation.
         /// </summary>
         public PoseDto pose { get; set; }
+
+        /// <summary>
+        /// If the pose can be interpolated
+        /// </summary>
+        public bool isInterpolable { get; set; }
+
+        /// <summary>
+        /// If the pose can be added to  other poses
+        /// </summary>
+        public bool isComposable { get; set; }
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/DTOs/PoseAnimator/PoseAnimatorDto.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/DTOs/PoseAnimator/PoseAnimatorDto.cs
@@ -53,14 +53,7 @@ namespace umi3d.common.userCapture.pose
         /// How long the pose should last [Not Implemented]
         /// </summary>
         public DurationDto duration { get; set; }
-        /// <summary>
-        /// If the pose can be interpolated
-        /// </summary>
-        public bool isInterpolable { get; set; }
-        /// <summary>
-        /// If the pose can be added to  other poses
-        /// </summary>
-        public bool isComposable { get; set; }
+
         /// <summary>
         /// How the pose is activated.
         /// </summary>

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/Serializers/PoseAnimationSerializerModule.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/Serializers/PoseAnimationSerializerModule.cs
@@ -48,13 +48,17 @@ namespace umi3d.common.userCapture.pose
                     {
                         readable = UMI3DSerializer.TryRead(container, out ulong id);
                         readable &= UMI3DSerializer.TryRead(container, out PoseDto pose);
+                        readable &= UMI3DSerializer.TryRead(container, out bool isInterpolable);
+                        readable &= UMI3DSerializer.TryRead(container, out bool isComposable);
 
                         if (readable)
                         {
                             PoseClipDto poseDto = new()
                             {
                                 id = id,
-                                pose = pose
+                                pose = pose,
+                                isInterpolable = isInterpolable,
+                                isComposable = isComposable
                             };
 
                             result = (T)Convert.ChangeType(poseDto, typeof(PoseClipDto));
@@ -69,9 +73,7 @@ namespace umi3d.common.userCapture.pose
                         readable &= UMI3DSerializer.TryRead(container, out bool isAnchored);
                         readable &= UMI3DSerializer.TryRead(container, out ulong relativeNodeId);
                         readable &= UMI3DSerializer.TryRead(container, out DurationDto durationDto);
-                        readable &= UMI3DSerializer.TryRead(container, out bool interpolable);
                         readable &= UMI3DSerializer.TryRead(container, out ushort activationMode);
-                        readable &= UMI3DSerializer.TryRead(container, out bool composable);
 
                         AbstractPoseConditionDto[] poseConditionDtos = UMI3DSerializer.ReadArray<AbstractPoseConditionDto>(container);
 
@@ -86,8 +88,6 @@ namespace umi3d.common.userCapture.pose
                                 poseConditions = poseConditionDtos,
                                 duration = durationDto,
                                 activationMode = activationMode,
-                                isInterpolable = interpolable,
-                                isComposable = composable
                             };
 
                             result = (T)Convert.ChangeType(poseOverriderDto, typeof(PoseAnimatorDto));
@@ -166,7 +166,9 @@ namespace umi3d.common.userCapture.pose
             {
                 case PoseClipDto poseDto:
                     bytable = UMI3DSerializer.Write(poseDto.id)
-                        + UMI3DSerializer.Write(poseDto.pose);
+                        + UMI3DSerializer.Write(poseDto.pose)
+                        + UMI3DSerializer.Write(poseDto.isInterpolable)
+                        + UMI3DSerializer.Write(poseDto.isComposable);
                     break;
 
                 case PoseAnimatorDto poseOverriderDto:
@@ -175,9 +177,7 @@ namespace umi3d.common.userCapture.pose
                         + UMI3DSerializer.Write(poseOverriderDto.isAnchored)
                         + UMI3DSerializer.Write(poseOverriderDto.relatedNodeId)
                         + UMI3DSerializer.Write(poseOverriderDto.duration)
-                        + UMI3DSerializer.Write(poseOverriderDto.isInterpolable)
                         + UMI3DSerializer.Write(poseOverriderDto.activationMode)
-                        + UMI3DSerializer.Write(poseOverriderDto.isComposable)
                         + UMI3DSerializer.WriteCollection(poseOverriderDto.poseConditions);
                     break;
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/UserCapture/Runtime/Pose/Components/PoseAnimator/UMI3DPoseAnimator.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/UserCapture/Runtime/Pose/Components/PoseAnimator/UMI3DPoseAnimator.cs
@@ -160,13 +160,6 @@ namespace umi3d.common.userCapture.pose
         [Tooltip("Expected duration of the pose animation.")]
         public Duration duration;
 
-        [Tooltip("Can the pose animation be interpolated when it is applied?")]
-        [HideInInspector]
-        public bool interpolable;
-
-        [Tooltip("Can the pose animation be composed with another pose animation?")]
-        public bool composable;
-
         [SerializeField, Tooltip("Related node. If unset, target is current node.")]
         private UMI3DNode relativeNode;
 
@@ -249,8 +242,6 @@ namespace umi3d.common.userCapture.pose
                 poseClipId = PoseClip.Id(),
                 poseConditions = ActivationsConditions.Select(x => x.ToDto()).ToArray(),
                 duration = duration.ToDto(),
-                isInterpolable = interpolable,
-                isComposable = composable,
                 activationMode = (ushort)activationMode
             };
         }

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/UserCapture/Runtime/Pose/Objects/PoseClip.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/UserCapture/Runtime/Pose/Objects/PoseClip.cs
@@ -47,13 +47,25 @@ namespace umi3d.edk.userCapture.pose
         /// </summary>
         public IList<BoneDto> Bones => poseResource.Bones;
 
+        /// <summary>
+        /// See <see cref="PoseClipDto.isComposable"/>.
+        /// </summary>
+        public bool IsComposable = true;
+
+        /// <summary>
+        /// See <see cref="PoseClipDto.isInterpolable"/>.
+        /// </summary>
+        public bool IsInterpolable = true;
+
         /// <inheritdoc/>
         public override IEntity ToEntityDto(UMI3DUser user)
         {
             return new PoseClipDto()
             {
                 id = Id(),
-                pose = poseResource.ToPoseDto()
+                pose = poseResource.ToPoseDto(),
+                isInterpolable = IsInterpolable,
+                isComposable = IsComposable,
             };
         }
 

--- a/UMI3D-SDK/ProjectSettings/EditorBuildSettings.asset
+++ b/UMI3D-SDK/ProjectSettings/EditorBuildSettings.asset
@@ -8,9 +8,9 @@ EditorBuildSettings:
   - enabled: 0
     path: 
     guid: 00000000000000000000000000000000
-  - enabled: 1
-    path: Assets/Tests/PlayMode_Tests/TestScenes/TESTSCENE_EDK_Bindings.unity
-    guid: 28baf46180f581047a8552c736bbb5ab
+  - enabled: 0
+    path: 
+    guid: 00000000000000000000000000000000
   - enabled: 1
     path: Assets/Tests/PlayMode_Tests/TestScenes/TESTSCENE_Empty.unity
     guid: 5e8cf43c8408df14fb8786a068d215a1


### PR DESCRIPTION
Pose playing is now managed by pose players that are controlled by the PoseSubskeleton. The usage of PoseClip IDs in tracking frames force to use PoseClip to convey the information about pose interpolation so that browsers are able to interpolate poses from other users.