### PR TITLE
Prevent from adding anchor or controllers on none bonetype

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/PoseSubskeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Pose/PoseSubskeleton.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Linq;
 using umi3d.cdk.userCapture.tracking;
 using umi3d.common;
+using umi3d.common.userCapture;
 using umi3d.common.userCapture.description;
 using umi3d.common.userCapture.tracking;
 
@@ -141,7 +142,7 @@ namespace umi3d.cdk.userCapture.pose
             SubskeletonDescriptionInterpolationPlayer player = AddPoseClipPlayer(poseToAdd, anchorToForce ?? poseToAdd.Pose.anchor);
 
             PoseAnchorDto anchor = posePlayingControllers[poseToAdd].Anchor;
-            if (anchor != null)
+            if (anchor != null && anchor.bone is not BoneType.None)
                 trackerSimulator.StartTrackerSimulation(anchor);
 
             player.Play(parameters);

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/TrackedSubskeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/TrackedSubskeleton.cs
@@ -285,6 +285,12 @@ namespace umi3d.cdk.userCapture.tracking
         /// <param name="saveOldController">If true the removed controlled is saved and will be used when the replacing controller will be deleted.</param>
         public void ReplaceController(IController newController, bool saveOldController = false)
         {
+            if (newController.boneType is BoneType.None) // cannot put a controller on none bonetype
+            {
+                UMI3DLogger.LogWarning($"Impossible to add controller. None bone type cannot receive a controller.", DebugScope.CDK | DebugScope.UserCapture);
+                return;
+            }
+
             if (saveOldController && controllers.TryGetValue(newController.boneType, out IController oldController))
             {
                 oldController.isActive = false;


### PR DESCRIPTION
Triggered e.g. by wrongly formatted poses