### PR TITLE
Replace async void test methods by direct execution

### DIFF
--- a/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/Collaboration/Emotes/EmoteLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/Collaboration/Emotes/EmoteLoader_Test.cs
@@ -18,6 +18,7 @@ using Moq;
 using NUnit.Framework;
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using umi3d.cdk;
 using umi3d.cdk.collaboration.emotes;
 using umi3d.common;
@@ -48,7 +49,7 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
         #region ReadUMI3DExtension
 
         [Test, Pairwise]
-        public async void ReadUMI3DExtension_Emote(
+        public void ReadUMI3DExtension_Emote(
             [Range(1000uL, 2000ul, 500ul)] ulong id,
             [Values(true, false)] bool available,
             [Range(1001uL, 2001ul, 500ul)] ulong animId,
@@ -71,7 +72,7 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
             environmentManagerMock.Setup(x => x.RegisterEntity(0, It.IsAny<ulong>(), It.IsAny<UMI3DEmoteDto>(), null, null)).Returns(new UMI3DNodeInstance(0, () => { }, 0));
 
             // WHEN
-            await emoteLoader.ReadUMI3DExtension(data);
+            Task.Run(() => emoteLoader.ReadUMI3DExtension(data)).Wait();
 
             // THEN
             emoteManagerMock.Verify(x => x.UpdateEmote(emoteDto));
@@ -116,7 +117,7 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
         #region SetUMI3DProperty
 
         [Test]
-        public async void SetUMI3DProperty_NotEmoteDto()
+        public void SetUMI3DProperty_NotEmoteDto()
         {
             // GIVEN
             var setEntityDto = new SetEntityPropertyDto()
@@ -133,14 +134,14 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
             var data = new SetUMI3DPropertyData(0, setEntityDto, entityInstance);
 
             // WHEN
-            var success = await emoteLoader.SetUMI3DProperty(data);
+            bool success = Task.Run(() => emoteLoader.SetUMI3DProperty(data)).Result;
 
             // THEN
             Assert.IsFalse(success);
         }
 
         [Test]
-        public async void SetUMI3DProperty_ActiveEmote([Values(true, false)] bool value)
+        public void SetUMI3DProperty_ActiveEmote([Values(true, false)] bool value)
         {
             // GIVEN
             var setEntityDto = new SetEntityPropertyDto()
@@ -157,7 +158,7 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
             var data = new SetUMI3DPropertyData(0, setEntityDto, entityInstance);
 
             // WHEN
-            var success = await emoteLoader.SetUMI3DProperty(data);
+            bool success = Task.Run(() => emoteLoader.SetUMI3DProperty(data)).Result;
 
             // THEN
             Assert.IsTrue(success);
@@ -165,7 +166,7 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
         }
 
         [Test]
-        public async void SetUMI3DProperty_AnimationEmote([Range(0ul, 2000uL, 500uL)] ulong value)
+        public void SetUMI3DProperty_AnimationEmote([Range(0ul, 2000uL, 500uL)] ulong value)
         {
             // GIVEN
             var setEntityDto = new SetEntityPropertyDto()
@@ -182,7 +183,7 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
             var data = new SetUMI3DPropertyData(0, setEntityDto, entityInstance);
 
             // WHEN
-            var success = await emoteLoader.SetUMI3DProperty(data);
+            bool success = Task.Run(() => emoteLoader.SetUMI3DProperty(data)).Result;
 
             // THEN
             Assert.IsTrue(success);
@@ -239,7 +240,7 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
         [Test]
         [TestCase(UMI3DPropertyKeys.ActiveEmote)]
         [TestCase(UMI3DPropertyKeys.AnimationEmote)]
-        public async void ReadUMI3DProperty(uint propertyKey)
+        public void ReadUMI3DProperty(uint propertyKey)
         {
             // set up
             var serializationModules = UMI3DSerializerModuleUtils.GetModules().ToList();
@@ -257,7 +258,7 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
                                                                 container: byteContainer);
 
             // WHEN
-            bool success = await emoteLoader.ReadUMI3DProperty(readUMI3DPropertyData);
+            bool success = Task.Run(() => emoteLoader.ReadUMI3DProperty(readUMI3DPropertyData)).Result;
 
             // THEN
             Assert.IsTrue(success);

--- a/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/Collaboration/Emotes/EmotesConfigLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/Collaboration/Emotes/EmotesConfigLoader_Test.cs
@@ -17,6 +17,7 @@ limitations under the License.
 using Moq;
 using NUnit.Framework;
 using System.Linq;
+using System.Threading.Tasks;
 using umi3d.cdk;
 using umi3d.cdk.collaboration.emotes;
 using umi3d.common;
@@ -80,7 +81,7 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
         #region ReadUMI3DExtension
 
         [Test]
-        public async void ReadUMI3DExtension_EmoteConfig(
+        public void ReadUMI3DExtension_EmoteConfig(
             [Range(1000uL, 2000ul, 500ul)] ulong id)
         {
             // GIVEN
@@ -102,7 +103,7 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
             var data = new ReadUMI3DExtensionData(0, dto);
 
             // WHEN
-            await emotesConfigLoader.ReadUMI3DExtension(data);
+            Task.Run(() => emotesConfigLoader.ReadUMI3DExtension(data)).Wait();
 
             // THEN
             emoteManagerMock.Verify(x => x.UpdateEmoteConfig(dto), Times.Once());
@@ -130,14 +131,14 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
             var data = new SetUMI3DPropertyData(0, setEntityDto, entityInstance);
 
             // WHEN
-            var success = await emotesConfigLoader.SetUMI3DProperty(data);
+            bool success =  Task.Run(() => emotesConfigLoader.SetUMI3DProperty(data)).Result;
 
             // THEN
             Assert.IsFalse(success);
         }
 
         [Test]
-        public async void SetUMI3DProperty_ChangeEmoteConfig()
+        public void SetUMI3DProperty_ChangeEmoteConfig()
         {
             // GIVEN
             var setEntityDto = new SetEntityPropertyDto()
@@ -154,7 +155,7 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
             var data = new SetUMI3DPropertyData(0, setEntityDto, entityInstance);
 
             // WHEN
-            var success = await emotesConfigLoader.SetUMI3DProperty(data);
+            bool success = Task.Run(() => emotesConfigLoader.SetUMI3DProperty(data)).Result;
 
             // THEN
             Assert.IsTrue(success);
@@ -166,7 +167,7 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
         #region ReadUMI3DProperty
 
         [Test]
-        public async void ReadUMI3DProperty_IsNotEmotesConfig()
+        public void ReadUMI3DProperty_IsNotEmotesConfig()
         {
             // set up
             var serializationModules = UMI3DSerializerModuleUtils.GetModules().ToList();
@@ -184,10 +185,10 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
                                                                 container: byteContainer);
 
             // WHEN
-            var result = await emotesConfigLoader.ReadUMI3DProperty(readUMI3DPropertyData);
+            bool success = Task.Run(() => emotesConfigLoader.ReadUMI3DProperty(readUMI3DPropertyData)).Result;
 
             // THEN
-            Assert.IsFalse(result);
+            Assert.IsFalse(success);
             emoteManagerMock.Verify(x => x.UpdateEmoteConfig(It.IsAny<UMI3DEmotesConfigDto>()), Times.Never());
 
             // teardown
@@ -195,7 +196,7 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
         }
 
         [Test]
-        public async void ReadUMI3DProperty()
+        public void ReadUMI3DProperty()
         {
             // set up
             var serializationModules = UMI3DSerializerModuleUtils.GetModules().ToList();
@@ -213,7 +214,7 @@ namespace EditMode_Tests.Collaboration.Emotes.CDK
                                                                 container: byteContainer);
 
             // WHEN
-            bool success = await emotesConfigLoader.ReadUMI3DProperty(readUMI3DPropertyData);
+            bool success = Task.Run(() => emotesConfigLoader.ReadUMI3DProperty(readUMI3DPropertyData)).Result;
 
             // THEN
             Assert.IsTrue(success);

--- a/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Pose/Loader/PoseAnimatorLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Pose/Loader/PoseAnimatorLoader_Test.cs
@@ -78,7 +78,7 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
         }
 
         [Test, TestOf(nameof(PoseAnimatorLoader.Load))]
-        public async void Load()
+        public void Load()
         {
             // Given
             PoseAnimatorDto dto = new()
@@ -110,14 +110,14 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
                                   .Verifiable();
 
             // When
-            await poseAnimatorLoader.Load(UMI3DGlobalID.EnvironmentId, dto);
+            Task.Run(() => poseAnimatorLoader.Load(UMI3DGlobalID.EnvironmentId, dto)).Wait();
 
             // Then
             environmentServiceMock.Verify(x => x.RegisterEntity(UMI3DGlobalID.EnvironmentId, dto.id, dto, It.IsAny<PoseAnimator>(), It.IsAny<Action>()), Times.Once());
         }
 
         [Test]
-        public async void Load_Conditions()
+        public void Load_Conditions()
         {
             // Given
 
@@ -171,7 +171,7 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
             loadingServiceMock.Setup(x => x.WaitUntilEntityLoaded<PoseClip>(UMI3DGlobalID.EnvironmentId, poseClip.Id, null)).Returns(Task.FromResult(poseClip));
 
             // When
-            PoseAnimator poseAnimator = await poseAnimatorLoader.Load(UMI3DGlobalID.EnvironmentId, dto);
+            PoseAnimator poseAnimator = Task.Run(() => poseAnimatorLoader.Load(UMI3DGlobalID.EnvironmentId, dto)).Result;
 
             // Then
             Assert.AreEqual(dto.id, poseAnimator.Id);

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/Binding/CollaborationBindingLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/Binding/CollaborationBindingLoader_Test.cs
@@ -84,7 +84,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
         #region ReadUMI3DExtension
 
         [Test]
-        public override async void ReadUMI3DExtension_MultiBinding()
+        public override void ReadUMI3DExtension_MultiBinding()
         {
             // GIVEN
             ulong environmentId = UMI3DGlobalID.EnvironmentId;
@@ -120,7 +120,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
             collaborativeSkeletonManager.Setup(x => x.WaitForSkeleton(environmentId, userId, It.IsAny<List<CancellationToken>>())).Returns(Task.FromResult(skeletonMock.Object));
 
             // WHEN
-            await bindingLoader.ReadUMI3DExtension(extensionData);
+            Task.Run(() => bindingLoader.ReadUMI3DExtension(extensionData)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>()));
@@ -131,7 +131,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
         }
 
         [Test]
-        public override async void ReadUMI3DExtension_NodeBinding()
+        public override void ReadUMI3DExtension_NodeBinding()
         {
             // GIVEN
             ulong environmentId = UMI3DGlobalID.EnvironmentId;
@@ -156,7 +156,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
             bindingManagementServiceMock.Setup(x => x.AddBinding(environmentId, dto.boundNodeId, It.IsAny<AbstractBinding>()));
 
             // WHEN
-            await bindingLoader.ReadUMI3DExtension(extensionData);
+            Task.Run(() => bindingLoader.ReadUMI3DExtension(extensionData)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>()));
@@ -167,7 +167,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
         }
 
         [Test]
-        public override async void ReadUMI3DExtension_BoneBinding()
+        public override void ReadUMI3DExtension_BoneBinding()
         {
             // GIVEN
             ulong environmentId = UMI3DGlobalID.EnvironmentId;
@@ -199,7 +199,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
             collaborativeSkeletonManager.Setup(x => x.WaitForSkeleton(environmentId, userId, It.IsAny<List<CancellationToken>>())).Returns(Task.FromResult(skeletonMock.Object));
 
             // WHEN
-            await bindingLoader.ReadUMI3DExtension(extensionData);
+            Task.Run(() => bindingLoader.ReadUMI3DExtension(extensionData)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>()));

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Core/Binding/BindingLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Core/Binding/BindingLoader_Test.cs
@@ -111,7 +111,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
         #region ReadUMI3DExtension
 
         [Test]
-        public virtual async void ReadUMI3DExtension_NodeBinding()
+        public virtual void ReadUMI3DExtension_NodeBinding()
         {
             // GIVEN
             ulong environmentId = 0uL;
@@ -136,7 +136,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
             bindingManagementServiceMock.Setup(x => x.AddBinding(environmentId, dto.boundNodeId, It.IsAny<AbstractBinding>()));
            
             // WHEN
-            await bindingLoader.ReadUMI3DExtension(extensionData);
+            Task.Run(() => bindingLoader.ReadUMI3DExtension(extensionData)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>()));
@@ -144,7 +144,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
         }
 
         [Test]
-        public virtual async void ReadUMI3DExtension_MultiBinding()
+        public virtual void ReadUMI3DExtension_MultiBinding()
         {
             // GIVEN
             ulong environmentId = 0uL;
@@ -169,7 +169,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
             bindingManagementServiceMock.Setup(x => x.AddBinding(environmentId, dto.boundNodeId, It.IsAny<AbstractBinding>()));
 
             // WHEN
-            await bindingLoader.ReadUMI3DExtension(extensionData);
+            Task.Run(() => bindingLoader.ReadUMI3DExtension(extensionData)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>()));

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Animation/SkeletonAnimationNodeLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Animation/SkeletonAnimationNodeLoader_Test.cs
@@ -157,7 +157,7 @@ namespace PlayMode_Tests.UserCapture.Animation.CDK
         #region ReadUMI3DExtension
 
         [Test]
-        public async void ReadUMI3DExtension_SkeletonAnimatioNode_WithoutSkeletonMapper_NoAvatar()
+        public void ReadUMI3DExtension_SkeletonAnimatioNode_WithoutSkeletonMapper_NoAvatar()
         {
             // GIVEN
             var dto = new SkeletonAnimationNodeDto()
@@ -194,7 +194,7 @@ namespace PlayMode_Tests.UserCapture.Animation.CDK
             var data = new ReadUMI3DExtensionData(UMI3DGlobalID.EnvironmentId, dto) { node = skeletonNodeGo };
 
             // WHEN
-            await skeletonAnimationNodeLoader.ReadUMI3DExtension(data);
+            Task.Run(() => skeletonAnimationNodeLoader.ReadUMI3DExtension(data)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.GetNodeInstance(UMI3DGlobalID.EnvironmentId, dto.id));

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/UserCaptureBindingLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/UserCaptureBindingLoader_Test.cs
@@ -77,7 +77,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
         #region ReadUMI3DExtension
 
         [Test]
-        public override async void ReadUMI3DExtension_MultiBinding()
+        public override void ReadUMI3DExtension_MultiBinding()
         {
             // GIVEN
             ulong environmentId = 0uL;
@@ -109,7 +109,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
             skeletonServiceMock.Setup(x => x.PersonalSkeleton).Returns(personalSkeletonMock.Object);
 
             // WHEN
-            await bindingLoader.ReadUMI3DExtension(extensionData);
+            Task.Run(() => bindingLoader.ReadUMI3DExtension(extensionData)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>()));
@@ -120,7 +120,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
         }
 
         [Test]
-        public virtual async void ReadUMI3DExtension_BoneBinding()
+        public virtual void ReadUMI3DExtension_BoneBinding()
         {
             // GIVEN
             ulong environmentId = 0uL;
@@ -151,7 +151,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
             bindingManagementServiceMock.Setup(x => x.AddBinding(environmentId, dto.boundNodeId, It.IsAny<AbstractBinding>()));
 
             // WHEN
-            await bindingLoader.ReadUMI3DExtension(extensionData);
+            Task.Run(() => bindingLoader.ReadUMI3DExtension(extensionData)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>()));


### PR DESCRIPTION
Used version of NUnit does not support aync void method as test methods, such tests are thus always marked as passed by mistake. Forcing execution prevent this.