### PR TITLE
Replace async void test methods by direct execution

### DIFF
--- a/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Pose/Loader/PoseAnimatorLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Pose/Loader/PoseAnimatorLoader_Test.cs
@@ -78,7 +78,7 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
         }
 
         [Test, TestOf(nameof(PoseAnimatorLoader.Load))]
-        public async void Load()
+        public void Load()
         {
             // Given
             PoseAnimatorDto dto = new()
@@ -110,14 +110,14 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
                                   .Verifiable();
 
             // When
-            await poseAnimatorLoader.Load(UMI3DGlobalID.EnvironmentId, dto);
+            Task.Run(() => poseAnimatorLoader.Load(UMI3DGlobalID.EnvironmentId, dto)).Wait();
 
             // Then
             environmentServiceMock.Verify(x => x.RegisterEntity(UMI3DGlobalID.EnvironmentId, dto.id, dto, It.IsAny<PoseAnimator>(), It.IsAny<Action>()), Times.Once());
         }
 
         [Test]
-        public async void Load_Conditions()
+        public void Load_Conditions()
         {
             // Given
 
@@ -171,7 +171,7 @@ namespace EditMode_Tests.UserCapture.Pose.CDK
             loadingServiceMock.Setup(x => x.WaitUntilEntityLoaded<PoseClip>(UMI3DGlobalID.EnvironmentId, poseClip.Id, null)).Returns(Task.FromResult(poseClip));
 
             // When
-            PoseAnimator poseAnimator = await poseAnimatorLoader.Load(UMI3DGlobalID.EnvironmentId, dto);
+            PoseAnimator poseAnimator = Task.Run(() => poseAnimatorLoader.Load(UMI3DGlobalID.EnvironmentId, dto)).Result;
 
             // Then
             Assert.AreEqual(dto.id, poseAnimator.Id);

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/Binding/CollaborationBindingLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/Binding/CollaborationBindingLoader_Test.cs
@@ -84,7 +84,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
         #region ReadUMI3DExtension
 
         [Test]
-        public override async void ReadUMI3DExtension_MultiBinding()
+        public override void ReadUMI3DExtension_MultiBinding()
         {
             // GIVEN
             ulong environmentId = UMI3DGlobalID.EnvironmentId;
@@ -120,7 +120,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
             collaborativeSkeletonManager.Setup(x => x.WaitForSkeleton(environmentId, userId, It.IsAny<List<CancellationToken>>())).Returns(Task.FromResult(skeletonMock.Object));
 
             // WHEN
-            await bindingLoader.ReadUMI3DExtension(extensionData);
+            Task.Run(() => bindingLoader.ReadUMI3DExtension(extensionData)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>()));
@@ -131,7 +131,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
         }
 
         [Test]
-        public override async void ReadUMI3DExtension_NodeBinding()
+        public override void ReadUMI3DExtension_NodeBinding()
         {
             // GIVEN
             ulong environmentId = UMI3DGlobalID.EnvironmentId;
@@ -156,7 +156,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
             bindingManagementServiceMock.Setup(x => x.AddBinding(environmentId, dto.boundNodeId, It.IsAny<AbstractBinding>()));
 
             // WHEN
-            await bindingLoader.ReadUMI3DExtension(extensionData);
+            Task.Run(() => bindingLoader.ReadUMI3DExtension(extensionData)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>()));
@@ -167,7 +167,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
         }
 
         [Test]
-        public override async void ReadUMI3DExtension_BoneBinding()
+        public override void ReadUMI3DExtension_BoneBinding()
         {
             // GIVEN
             ulong environmentId = UMI3DGlobalID.EnvironmentId;
@@ -199,7 +199,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
             collaborativeSkeletonManager.Setup(x => x.WaitForSkeleton(environmentId, userId, It.IsAny<List<CancellationToken>>())).Returns(Task.FromResult(skeletonMock.Object));
 
             // WHEN
-            await bindingLoader.ReadUMI3DExtension(extensionData);
+            Task.Run(() => bindingLoader.ReadUMI3DExtension(extensionData)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>()));

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Core/Binding/BindingLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Core/Binding/BindingLoader_Test.cs
@@ -111,7 +111,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
         #region ReadUMI3DExtension
 
         [Test]
-        public virtual async void ReadUMI3DExtension_NodeBinding()
+        public virtual void ReadUMI3DExtension_NodeBinding()
         {
             // GIVEN
             ulong environmentId = 0uL;
@@ -136,7 +136,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
             bindingManagementServiceMock.Setup(x => x.AddBinding(environmentId, dto.boundNodeId, It.IsAny<AbstractBinding>()));
            
             // WHEN
-            await bindingLoader.ReadUMI3DExtension(extensionData);
+            Task.Run(() => bindingLoader.ReadUMI3DExtension(extensionData)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>()));
@@ -144,7 +144,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
         }
 
         [Test]
-        public virtual async void ReadUMI3DExtension_MultiBinding()
+        public virtual void ReadUMI3DExtension_MultiBinding()
         {
             // GIVEN
             ulong environmentId = 0uL;
@@ -169,7 +169,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
             bindingManagementServiceMock.Setup(x => x.AddBinding(environmentId, dto.boundNodeId, It.IsAny<AbstractBinding>()));
 
             // WHEN
-            await bindingLoader.ReadUMI3DExtension(extensionData);
+            Task.Run(() => bindingLoader.ReadUMI3DExtension(extensionData)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>()));

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Animation/SkeletonAnimationNodeLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Animation/SkeletonAnimationNodeLoader_Test.cs
@@ -157,7 +157,7 @@ namespace PlayMode_Tests.UserCapture.Animation.CDK
         #region ReadUMI3DExtension
 
         [Test]
-        public async void ReadUMI3DExtension_SkeletonAnimatioNode_WithoutSkeletonMapper_NoAvatar()
+        public void ReadUMI3DExtension_SkeletonAnimatioNode_WithoutSkeletonMapper_NoAvatar()
         {
             // GIVEN
             var dto = new SkeletonAnimationNodeDto()
@@ -194,7 +194,7 @@ namespace PlayMode_Tests.UserCapture.Animation.CDK
             var data = new ReadUMI3DExtensionData(UMI3DGlobalID.EnvironmentId, dto) { node = skeletonNodeGo };
 
             // WHEN
-            await skeletonAnimationNodeLoader.ReadUMI3DExtension(data);
+            Task.Run(() => skeletonAnimationNodeLoader.ReadUMI3DExtension(data)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.GetNodeInstance(UMI3DGlobalID.EnvironmentId, dto.id));

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/UserCaptureBindingLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/UserCaptureBindingLoader_Test.cs
@@ -77,7 +77,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
         #region ReadUMI3DExtension
 
         [Test]
-        public override async void ReadUMI3DExtension_MultiBinding()
+        public override void ReadUMI3DExtension_MultiBinding()
         {
             // GIVEN
             ulong environmentId = 0uL;
@@ -109,7 +109,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
             skeletonServiceMock.Setup(x => x.PersonalSkeleton).Returns(personalSkeletonMock.Object);
 
             // WHEN
-            await bindingLoader.ReadUMI3DExtension(extensionData);
+            Task.Run(() => bindingLoader.ReadUMI3DExtension(extensionData)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>()));
@@ -120,7 +120,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
         }
 
         [Test]
-        public virtual async void ReadUMI3DExtension_BoneBinding()
+        public virtual void ReadUMI3DExtension_BoneBinding()
         {
             // GIVEN
             ulong environmentId = 0uL;
@@ -151,7 +151,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
             bindingManagementServiceMock.Setup(x => x.AddBinding(environmentId, dto.boundNodeId, It.IsAny<AbstractBinding>()));
 
             // WHEN
-            await bindingLoader.ReadUMI3DExtension(extensionData);
+            Task.Run(() => bindingLoader.ReadUMI3DExtension(extensionData)).Wait();
 
             // THEN
             environmentManagerMock.Verify(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>()));


### PR DESCRIPTION
Used version of NUnit does not support aync void method as test methods, such tests are thus always marked as passed by mistake. Forcing execution prevent this.

# Conflicts:
#	UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/Collaboration/Emotes/EmoteLoader_Test.cs #	UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/Collaboration/Emotes/EmotesConfigLoader_Test.cs

Problems of async were already solved