### PR TITLE
Feature/us 9390 restrict bone movements

### DIFF
--- a/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Tracking/Constraints/Loader/BoneConstraintLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Tracking/Constraints/Loader/BoneConstraintLoader_Test.cs
@@ -24,6 +24,7 @@ using umi3d.cdk;
 using umi3d.cdk.userCapture;
 using umi3d.cdk.userCapture.tracking.constraint;
 using umi3d.common;
+using umi3d.common.core;
 using umi3d.common.userCapture;
 using umi3d.common.userCapture.tracking.constraint;
 using UnityEngine;
@@ -136,7 +137,7 @@ namespace EditMode_Tests.UserCapture.Tracking.Constraint.CDK
             };
 
             var personalSkeletonMock = new Mock<IPersonalSkeleton>();
-            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ISkeleton.Transformation>() { { dto.ConstrainingBone, new() } });
+            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ITransformation>() { { dto.ConstrainingBone, new PureTransformation() } });
 
             skeletonServiceMock.Setup(x => x.PersonalSkeleton).Returns(personalSkeletonMock.Object);
 
@@ -356,7 +357,7 @@ namespace EditMode_Tests.UserCapture.Tracking.Constraint.CDK
                 RotationOffset = Quaternion.Euler(Vector3.one).Dto()
             };
 
-            BoneBoneConstraint boneBoneConstraint = new(dto, new());
+            BoneBoneConstraint boneBoneConstraint = new(dto, new PureTransformation());
 
             UMI3DEntityInstance entityInstance = new(environmentId, () => { }, boneBoneConstraint.Id)
             {
@@ -369,7 +370,7 @@ namespace EditMode_Tests.UserCapture.Tracking.Constraint.CDK
             environmentServiceMock.Setup(x => x.TryGetEntity(environmentId, boneBoneConstraint.Id, out boneBoneConstraint)).Returns(true);
 
             var personalSkeletonMock = new Mock<IPersonalSkeleton>();
-            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ISkeleton.Transformation>() { { value, new() } });
+            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ITransformation>() { { value, new PureTransformation() } });
 
             skeletonServiceMock.Setup(x => x.PersonalSkeleton).Returns(personalSkeletonMock.Object);
 

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/Binding/CollaborationBindingLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/Binding/CollaborationBindingLoader_Test.cs
@@ -27,6 +27,7 @@ using umi3d.cdk.collaboration.userCapture;
 using umi3d.cdk.collaboration.userCapture.binding;
 using umi3d.cdk.userCapture;
 using umi3d.common;
+using umi3d.common.core;
 using umi3d.common.dto.binding;
 using umi3d.common.userCapture;
 using umi3d.common.userCapture.binding;
@@ -109,7 +110,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
             nodeMock.Setup(x => x.transform).Returns(nodeGameObject.transform);
 
             var skeletonMock = new Mock<ISkeleton>();
-            skeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ISkeleton.Transformation>() { { targetBoneType, new() } });
+            skeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ITransformation>() { { targetBoneType, new PureTransformation() } });
             
             loadingManagerMock.Setup(x => x.WaitUntilNodeInstanceLoaded(environmentId, dto.boundNodeId, null)).Returns(Task.FromResult(nodeMock.Object));
             environmentManagerMock.Setup(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>())).Returns(entityFake);
@@ -188,7 +189,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
             nodeMock.Setup(x => x.transform).Returns(nodeGameObject.transform);
 
             var skeletonMock = new Mock<ISkeleton>();
-            skeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ISkeleton.Transformation>() { { targetBoneType, new() } });
+            skeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ITransformation>() { { targetBoneType, new PureTransformation() } });
 
             loadingManagerMock.Setup(x => x.WaitUntilNodeInstanceLoaded(environmentId, dto.boundNodeId, null)).Returns(Task.FromResult(nodeMock.Object));
             environmentManagerMock.Setup(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>())).Returns(entityFake);

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Animation/SkeletonAnimationNodeLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Animation/SkeletonAnimationNodeLoader_Test.cs
@@ -160,6 +160,7 @@ namespace PlayMode_Tests.UserCapture.Animation.CDK
         public void ReadUMI3DExtension_SkeletonAnimatioNode_WithoutSkeletonMapper_NoAvatar()
         {
             // GIVEN
+            ulong environmentId = UMI3DGlobalID.EnvironmentId;
             var dto = new SkeletonAnimationNodeDto()
             {
                 id = 1005uL,
@@ -176,13 +177,13 @@ namespace PlayMode_Tests.UserCapture.Animation.CDK
             glTFNodeDto.extensions = new GlTFNodeExtensions();
             glTFNodeDto.extensions.umi3d = dto;
 
-            var instance = new UMI3DNodeInstance(UMI3DGlobalID.EnvironmentId, () => { })
+            var instance = new UMI3DNodeInstance(environmentId, () => { })
             {
                 dto = glTFNodeDto,
                 gameObject = skeletonNodeGo
             };
 
-            environmentManagerMock.Setup(x => x.GetNodeInstance(UMI3DGlobalID.EnvironmentId, dto.id)).Returns(instance);
+            environmentManagerMock.Setup(x => x.GetNodeInstance(environmentId, dto.id)).Returns(instance);
             personnalSkeletonServiceMock.Setup(x => x.PersonalSkeleton).Returns(personalSkeleton);
             var loadingParametersMock = new Mock<IUMI3DUserCaptureLoadingParameters>();
             loadingManagerMock.Setup(x => x.AbstractLoadingParameters).Returns(loadingParametersMock.Object);
@@ -191,13 +192,13 @@ namespace PlayMode_Tests.UserCapture.Animation.CDK
             clientServerMock.Setup(x => x.OnLeavingEnvironment).Returns(new UnityEvent());
             loadingParametersMock.Setup(x => x.SelectLoader(It.IsAny<string>())).Returns(new ObjMeshDtoLoader());
 
-            var data = new ReadUMI3DExtensionData(UMI3DGlobalID.EnvironmentId, dto) { node = skeletonNodeGo };
+            var data = new ReadUMI3DExtensionData(environmentId, dto) { node = skeletonNodeGo };
 
             // WHEN
             Task.Run(() => skeletonAnimationNodeLoader.ReadUMI3DExtension(data)).Wait();
 
             // THEN
-            environmentManagerMock.Verify(x => x.GetNodeInstance(UMI3DGlobalID.EnvironmentId, dto.id));
+            environmentManagerMock.Verify(x => x.GetNodeInstance(environmentId, dto.id));
             personnalSkeletonServiceMock.Verify(x => x.PersonalSkeleton, Times.Never());
         }
 

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/BoneBinding_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/BoneBinding_Test.cs
@@ -27,6 +27,7 @@ using UnityEngine.SceneManagement;
 using UnityEngine.TestTools;
 using TestUtils.UserCapture;
 using TestUtils;
+using umi3d.common.core;
 
 namespace PlayMode_Tests.UserCapture.Binding.CDK
 {
@@ -90,9 +91,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ISkeleton.Transformation>()
+            var skeletonBones = new Dictionary<uint, ITransformation>()
             {
-                { boneType, new() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -127,9 +128,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ISkeleton.Transformation>()
+            var skeletonBones = new Dictionary<uint, ITransformation>()
             {
-                { boneType, new() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -182,9 +183,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ISkeleton.Transformation>()
+            var skeletonBones = new Dictionary<uint, ITransformation>()
             {
-                { boneType, new() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -218,9 +219,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ISkeleton.Transformation>()
+            var skeletonBones = new Dictionary<uint, ITransformation>()
             {
-                { boneType, new() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -271,9 +272,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ISkeleton.Transformation>()
+            var skeletonBones = new Dictionary<uint, ITransformation>()
             {
-                { boneType, new() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -308,9 +309,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ISkeleton.Transformation>()
+            var skeletonBones = new Dictionary<uint, ITransformation>()
             {
-                { boneType, new() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/RigBoneBinding_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/RigBoneBinding_Test.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using TestUtils;
 using umi3d.cdk.userCapture;
 using umi3d.cdk.userCapture.binding;
+using umi3d.common.core;
 using umi3d.common.userCapture;
 using umi3d.common.userCapture.binding;
 using UnityEngine;
@@ -98,9 +99,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ISkeleton.Transformation>()
+            var skeletonBones = new Dictionary<uint, ITransformation>()
             {
-                { boneType, new() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -135,9 +136,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ISkeleton.Transformation>()
+            var skeletonBones = new Dictionary<uint, ITransformation>()
             {
-                { boneType, new() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -190,9 +191,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ISkeleton.Transformation>()
+            var skeletonBones = new Dictionary<uint, ITransformation>()
             {
-                { boneType, new() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -226,9 +227,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ISkeleton.Transformation>()
+            var skeletonBones = new Dictionary<uint, ITransformation>()
             {
-                { boneType, new() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -279,9 +280,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ISkeleton.Transformation>()
+            var skeletonBones = new Dictionary<uint, ITransformation>()
             {
-                { boneType, new() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -316,9 +317,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ISkeleton.Transformation>()
+            var skeletonBones = new Dictionary<uint, ITransformation>()
             {
-                { boneType, new() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/UserCaptureBindingLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/UserCaptureBindingLoader_Test.cs
@@ -29,6 +29,7 @@ using umi3d.common.userCapture;
 using umi3d.common.userCapture.binding;
 using UnityEngine.SocialPlatforms.GameCenter;
 using UnityEngine;
+using umi3d.common.core;
 
 namespace PlayMode_Tests.UserCapture.Binding.CDK
 {
@@ -98,7 +99,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
             nodeMock.Setup(x => x.transform).Returns(nodeGameObject.transform);
 
             var personalSkeletonMock = new Mock<IPersonalSkeleton>();
-            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ISkeleton.Transformation>() { { targetBoneType, new() } });
+            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ITransformation>() { { targetBoneType, new PureTransformation() } });
 
             loadingManagerMock.Setup(x => x.WaitUntilNodeInstanceLoaded(environmentId, dto.boundNodeId, null)).Returns(Task.FromResult(nodeMock.Object));
             environmentManagerMock.Setup(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>())).Returns(entityFake);
@@ -140,7 +141,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
             nodeMock.Setup(x => x.transform).Returns(nodeGameObject.transform);
 
             var personalSkeletonMock = new Mock<IPersonalSkeleton>();
-            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ISkeleton.Transformation>() { { targetBoneType, new()} });
+            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ITransformation>() { { targetBoneType, new PureTransformation()} });
 
             loadingManagerMock.Setup(x => x.WaitUntilNodeInstanceLoaded(environmentId, dto.boundNodeId, null)).Returns(Task.FromResult(nodeMock.Object));
             environmentManagerMock.Setup(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>())).Returns(entityFake);

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/SubskeletonDescriptionInterpolationPlayer_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/SubskeletonDescriptionInterpolationPlayer_Test.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Linq;
 using TestUtils.UserCapture;
 using umi3d.cdk.userCapture;
+using umi3d.common.core;
 using umi3d.common.userCapture.description;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -54,7 +55,7 @@ namespace PlayMode_Tests.UserCapture.CDK
             mockDescriptor = new();
             mockDescriptor.Setup(x => x.GetPose(It.IsAny<UMI3DSkeletonHierarchy>())).Returns(pose);
 
-            mockSkeleton.Setup(x => x.Bones).Returns(bones.ToDictionary(x => x.boneType, y => new ISkeleton.Transformation() { LocalRotation = Quaternion.identity, Position = Vector3.zero, Rotation = Quaternion.identity }));
+            mockSkeleton.Setup(x => x.Bones).Returns(bones.ToDictionary(x => x.boneType, y => (ITransformation)new PureTransformation() { LocalRotation = Quaternion.identity, Position = Vector3.zero, Rotation = Quaternion.identity }));
 
             player = new(mockDescriptor.Object, true, mockSkeleton.Object);
         }

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Tracking/Constraints/Objects/BoneBoneConstraint_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Tracking/Constraints/Objects/BoneBoneConstraint_Test.cs
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 using NUnit.Framework;
-using umi3d.cdk.userCapture;
 using umi3d.cdk.userCapture.tracking.constraint;
 using umi3d.common;
+using umi3d.common.core;
 using umi3d.common.userCapture;
 using umi3d.common.userCapture.tracking.constraint;
 using UnityEngine;
@@ -28,7 +28,7 @@ namespace PlayMode_Tests.UserCapture.Tracking.Constraint.CDK
     public class BoneBoneConstraint_Test : AbstractBoneConstraint_Test
     {
         private BoneBoneConstraint boneBoneConstraint;
-        private ISkeleton.Transformation boneTransformation;
+        private PureTransformation boneTransformation;
 
         #region Test SetUp
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Binding/Objects/BoneBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Binding/Objects/BoneBinding.cs
@@ -17,6 +17,7 @@ limitations under the License.
 using umi3d.cdk.binding;
 using umi3d.cdk.userCapture.tracking;
 using umi3d.common;
+using umi3d.common.core;
 using umi3d.common.userCapture.binding;
 using UnityEngine;
 
@@ -67,20 +68,22 @@ namespace umi3d.cdk.userCapture.binding
                 return;
             }
 
-            ISkeleton.Transformation parentBone;
+            ITransformation parentBone;
 
             if (!BindToController)
             {
                 parentBone = skeleton.Bones[BoneType];
             }
-            else if (skeleton.TrackedSubskeleton.Controllers.TryGetValue(BoneType, out IController controller) && controller is DistantController)
+            else if (skeleton.TrackedSubskeleton.Controllers.TryGetValue(BoneType, out IController controller) && controller is DistantController dc)
             {
-                parentBone = new()
+                GameObject go = new GameObject("Distant Controller");
+                parentBone = new UnityTransformation(go.transform)
                 {
                     Position = controller.position,
                     Rotation = controller.rotation,
                     Scale = controller.scale
                 };
+                dc.Destroyed += () => UnityEngine.Object.Destroy(go);
             }
             else
             {

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Interfaces/ISkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Interfaces/ISkeleton.cs
@@ -14,15 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-using System;
 using System.Collections.Generic;
 using umi3d.cdk.userCapture.animation;
 using umi3d.cdk.userCapture.pose;
 using umi3d.cdk.userCapture.tracking;
+using umi3d.common.core;
 using umi3d.common.userCapture;
 using umi3d.common.userCapture.description;
 using umi3d.common.userCapture.tracking;
-using UnityEngine;
 
 namespace umi3d.cdk.userCapture
 {
@@ -38,7 +37,7 @@ namespace umi3d.cdk.userCapture
         /// <summary>
         /// Position and rotation of each bone, indexed by UMI3D <see cref="BoneType"/>.
         /// </summary>
-        IDictionary<uint, Transformation> Bones { get; }
+        IReadOnlyDictionary<uint, ITransformation> Bones { get; }
 
         /// <summary>
         /// Subskeletons that compose the final skeleton.
@@ -100,17 +99,5 @@ namespace umi3d.cdk.userCapture
         /// </summary>
         /// <param name="subskeleton"></param>
         void RemoveSubskeleton(IAnimatedSubskeleton subskeleton);
-
-        #region Data struture
-
-        public class Transformation
-        {
-            public Vector3 Position;
-            public Quaternion Rotation;
-            public Quaternion LocalRotation; 
-            public Vector3 Scale = Vector3.one;
-        }
-
-        #endregion Data struture
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Interfaces/IUMI3DUserCaptureLoadingParameters.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Interfaces/IUMI3DUserCaptureLoadingParameters.cs
@@ -24,6 +24,7 @@ namespace umi3d.cdk.userCapture
     {
         IReadOnlyList<IUMI3DPoseData> ClientPoses { get; }
         IUMI3DSkeletonHierarchyDefinition SkeletonHierarchyDefinition { get; }
+        IUMI3DSkeletonMusclesDefinition SkeletonMusclesDefinition { get; }
         IList<uint> BonesWithControllers { get; }
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/PersonalSkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/PersonalSkeleton.cs
@@ -40,13 +40,10 @@ namespace umi3d.cdk.userCapture
         protected void Start()
         {
             PoseSubskeleton = new PoseSubskeleton(UMI3DGlobalID.EnvironmentId, this);
-
-            //Init(trackedSkeleton, PoseSubskeleton);
         }
 
         public void Init()
         {
-           
             Init(trackedSkeleton, PoseSubskeleton);
         }
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/PersonalSkeletonManager.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/PersonalSkeletonManager.cs
@@ -49,7 +49,8 @@ namespace umi3d.cdk.userCapture
         {
             get
             {
-                _standardHierarchy ??= new UMI3DSkeletonHierarchy((environmentLoaderService.AbstractLoadingParameters as UMI3DUserCaptureLoadingParameters).SkeletonHierarchyDefinition);
+                var userCaptureLoadingParameters = (IUMI3DUserCaptureLoadingParameters)environmentLoaderService.AbstractLoadingParameters;
+                _standardHierarchy ??= new UMI3DSkeletonHierarchy(userCaptureLoadingParameters.SkeletonHierarchyDefinition, userCaptureLoadingParameters.SkeletonMusclesDefinition);
                 return _standardHierarchy;
             }
         }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/Controller/DistantController.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/Controller/DistantController.cs
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+using umi3d.common.core;
 using UnityEngine;
 
 namespace umi3d.cdk.userCapture.tracking
@@ -25,18 +26,35 @@ namespace umi3d.cdk.userCapture.tracking
     {
         public uint boneType { get; set; }
 
-        public Vector3 position { get; set; }
+        public PureTransformation Transformation { get; set; } = new();
 
-        public Quaternion rotation { get; set; }
+        public Vector3 position
+        {
+            get => Transformation.Position;
+            set => Transformation.Position = value;
+        }
 
-        public Vector3 scale { get; set; } = Vector3.one;
+        public Quaternion rotation
+        {
+            get => Transformation.Rotation;
+            set => Transformation.Rotation = value;
+        }
+
+        public Vector3 scale
+        {
+            get => Transformation.Scale;
+            set => Transformation.Scale = value;
+        }
 
         public bool isActive { get; set; }
 
         public bool isOverrider { get; set; }
 
+        public event System.Action Destroyed;
+
         public void Destroy()
         {
+            Destroyed?.Invoke();
         }
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/TrackedSubskeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/TrackedSubskeleton.cs
@@ -61,8 +61,15 @@ namespace umi3d.cdk.userCapture.tracking
         public Transform hips;
         public Transform Hips => hips;
 
+        /// <summary>
+        /// Reference of IK Animator
+        /// </summary>
         [SerializeField]
         private Animator animator;
+
+        /// <summary>
+        /// Animator wrapper.
+        /// </summary>
         public TrackedAnimator trackedAnimator;
 
         [SerializeField]
@@ -86,9 +93,15 @@ namespace umi3d.cdk.userCapture.tracking
 
         public void Start()
         {
-            if (trackedAnimator == null)
+            if (trackedAnimator == null && !TryGetComponent(out trackedAnimator))
             {
-                UMI3DLogger.LogWarning("TrackedAnimator was null for TrackedSubskeleton. Generating a new one", DebugScope.CDK);
+                UMI3DLogger.LogWarning("TrackedAnimator not found for TrackedSubskeleton. Generating a new one", DebugScope.CDK);
+                if (animator == null)
+                {
+                    UMI3DLogger.LogWarning("Animator for IK not found. Generating a default one", DebugScope.CDK);
+                    animator = gameObject.AddComponent<Animator>();
+                    animator.Rebind();
+                }
                 trackedAnimator = gameObject.AddComponent<TrackedAnimator>();
             }
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/TrackerSimulation/Loader/BoneConstraintLoader.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/TrackerSimulation/Loader/BoneConstraintLoader.cs
@@ -16,6 +16,7 @@ limitations under the License.
 
 using System.Threading.Tasks;
 using umi3d.common;
+using umi3d.common.core;
 using umi3d.common.userCapture.tracking.constraint;
 
 namespace umi3d.cdk.userCapture.tracking.constraint
@@ -78,7 +79,7 @@ namespace umi3d.cdk.userCapture.tracking.constraint
                     }
                 case BoneBoneConstraintDto boneBoneConstraintDto:
                     {
-                        if (!skeletonService.PersonalSkeleton.Bones.TryGetValue(boneBoneConstraintDto.ConstrainingBone, out ISkeleton.Transformation boneReference))
+                        if (!skeletonService.PersonalSkeleton.Bones.TryGetValue(boneBoneConstraintDto.ConstrainingBone, out ITransformation boneReference))
                         {
                             await Task.Run(() => UMI3DLogger.LogWarning($"Bone {boneBoneConstraintDto.ConstrainingBone} not found for applying BoneBone constraint.", DEBUG_SCOPE));
                             break;
@@ -220,7 +221,7 @@ namespace umi3d.cdk.userCapture.tracking.constraint
             if (!environmentService.TryGetEntity(environmentId, entityId, out BoneBoneConstraint boneConstraint))
                 return;
 
-            if (!skeletonService.PersonalSkeleton.Bones.TryGetValue(bone, out ISkeleton.Transformation boneReference))
+            if (!skeletonService.PersonalSkeleton.Bones.TryGetValue(bone, out ITransformation boneReference))
                 return;
 
             boneConstraint.ConstrainingBoneTransform = boneReference;

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/TrackerSimulation/Objects/BoneConstraints/BoneBoneConstraint.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/TrackerSimulation/Objects/BoneConstraints/BoneBoneConstraint.cs
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 using umi3d.common;
+using umi3d.common.core;
 using umi3d.common.userCapture.tracking.constraint;
 using UnityEngine;
 
@@ -22,11 +23,11 @@ namespace umi3d.cdk.userCapture.tracking.constraint
 {
     public class BoneBoneConstraint : AbstractBoneConstraint
     {
-        public ISkeleton.Transformation ConstrainingBoneTransform { get; internal set; }
+        public ITransformation ConstrainingBoneTransform { get; internal set; }
 
         public uint ConstrainingBone { get; internal set; }
 
-        public BoneBoneConstraint(BoneBoneConstraintDto dto, ISkeleton.Transformation bone) : base(dto)
+        public BoneBoneConstraint(BoneBoneConstraintDto dto, ITransformation bone) : base(dto)
         {
             ConstrainingBone = dto.ConstrainingBone;
             ConstrainingBoneTransform = bone;

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/UMI3DUserCaptureLoadingParameters.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/UMI3DUserCaptureLoadingParameters.cs
@@ -34,6 +34,7 @@ namespace umi3d.cdk.userCapture
         [SerializeField, Tooltip("Hierarchy definition used to instantiate users' skeletons.")]
         private UMI3DSkeletonHierarchyDefinition skeletonHierarchyDefinition;
         public IUMI3DSkeletonHierarchyDefinition SkeletonHierarchyDefinition => skeletonHierarchyDefinition;
+        public IUMI3DSkeletonMusclesDefinition SkeletonMusclesDefinition => skeletonHierarchyDefinition;
 
         [Header("Poses")]
         [SerializeField, Tooltip("Specific poses defined by the browser.")]

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Utils/ITransformation.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Utils/ITransformation.cs
@@ -1,0 +1,96 @@
+﻿/*
+Copyright 2019 - 2024 Inetum
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+using UnityEngine;
+
+namespace umi3d.common.core
+{
+    public interface ITransformation
+    {
+        /// <summary>
+        /// World position (global space).
+        /// </summary>
+        public Vector3 Position { get; set; }
+
+        /// <summary>
+        /// World rotation (global space).
+        /// </summary>
+        public Quaternion Rotation { get; set; }
+
+        /// <summary>
+        /// Rotation relative to parent.
+        /// </summary>
+        public Quaternion LocalRotation { get; set; }
+
+        /// <summary>
+        /// Scale relative to parent.
+        /// </summary>
+        public Vector3 Scale { get; set; }
+    }
+
+    /// <summary>
+    /// Transformation container without a gameobject.
+    /// </summary>
+    /// Storage only. No logic is ensured.
+    public class PureTransformation : ITransformation
+    {
+        public Vector3 Position { get; set; } = Vector3.zero;
+
+        public Quaternion Rotation { get; set; } = Quaternion.identity;
+
+        public Quaternion LocalRotation { get; set; } = Quaternion.identity;
+
+        public Vector3 Scale { get; set; } = Vector3.one;
+    }
+
+    /// <summary>
+    /// Transformation wrapper for a Unity tranform.
+    /// </summary>
+    public class UnityTransformation : ITransformation
+    {
+        public Vector3 Position
+        {
+            get => Transform.position;
+            set => Transform.position = value;
+        }
+
+        public Quaternion Rotation
+        {
+            get => Transform.rotation;
+            set => Transform.rotation = value;
+        }
+
+        public Quaternion LocalRotation
+        {
+            get => Transform.localRotation;
+            set => Transform.localRotation = value;
+        }
+
+        public Vector3 Scale
+        {
+            get => Transform.localScale;
+            set => Transform.localScale = value;
+        }
+
+        public Transform Transform { get; }
+
+        public UnityTransformation(Transform transform)
+        {
+            Transform = transform;
+        }
+    }
+}

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Utils/ITransformation.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Utils/ITransformation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c058e7730d54e9e4d861cb8054597a3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Description/Hierarchy/IUMI3DSkeletonMusclesDefinition.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Description/Hierarchy/IUMI3DSkeletonMusclesDefinition.cs
@@ -1,0 +1,73 @@
+﻿/*
+Copyright 2019 - 2024 Inetum
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+namespace umi3d.common.userCapture.description
+{
+    public interface IUMI3DSkeletonMusclesDefinition
+    {
+        /// <summary>
+        /// Rotation restrictions to apply to bones.
+        /// </summary>
+        public List<Muscle> Muscles { get; }
+
+        /// <summary>
+        /// Constraint on a bone rotation.
+        /// </summary>
+        public struct Muscle
+        {
+            /// <summary>
+            /// Bone type in UMI3D standards.
+            /// </summary>
+            public uint Bonetype;
+
+            /// <summary>
+            /// Offset for restrictions.
+            /// </summary>
+            /// Typically used for fingers joints.
+            public Vector4Dto ReferenceFrameRotation;
+
+            /// <summary>
+            /// Rotation restriction on rotation axis X.
+            /// </summary>
+            public RotationRestriction? XRotationRestriction;
+
+            /// <summary>
+            /// Rotation restriction on rotation axis Y.
+            /// </summary>
+            public RotationRestriction? YRotationRestriction;
+
+            /// <summary>
+            /// Rotation restriction on rotation axis Z.
+            /// </summary>
+            public RotationRestriction? ZRotationRestriction;
+
+            public struct RotationRestriction
+            {
+                /// <summary>
+                /// Lowest tolerated angle in degrees.
+                /// </summary>
+                public float min;
+
+                /// <summary>
+                /// Greatest tolerated angle in degrees.
+                /// </summary>
+                public float max;
+            }
+        }
+    }
+}

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Description/Hierarchy/IUMI3DSkeletonMusclesDefinition.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Description/Hierarchy/IUMI3DSkeletonMusclesDefinition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5148b1956e3b78248a76083f981cfc30
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/UMI3DSkeletonHierarchyDefinition.asset
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/UMI3DSkeletonHierarchyDefinition.asset
@@ -178,3 +178,32 @@ MonoBehaviour:
   - Bonetype: 2
     BonetypeParent: 3
     RelativePosition: {x: 0.02944481, y: 0.07681751, z: 0.09120493}
+  _muscles:
+  - Bonetype: 12
+    ReferenceFrameRotation: {x: 0, y: 0, z: 0, w: 1}
+    XRotationRestriction:
+      isRestricted: 1
+      min: -40
+      max: 40
+    YRotationRestriction:
+      isRestricted: 1
+      min: -40
+      max: 40
+    ZRotationRestriction:
+      isRestricted: 1
+      min: -40
+      max: 40
+  - Bonetype: 3
+    ReferenceFrameRotation: {x: 0, y: 0, z: 0, w: 1}
+    XRotationRestriction:
+      isRestricted: 1
+      min: -40
+      max: 40
+    YRotationRestriction:
+      isRestricted: 1
+      min: -40
+      max: 40
+    ZRotationRestriction:
+      isRestricted: 1
+      min: -40
+      max: 40


### PR DESCRIPTION
- Add Muscles to represent rotation restrictions in a UMI3D hierarchy SO
- Add Transformation interface
- Computation of final skeleton is now done on a hierarchy of gameObject with a GET logic
- Add events for start of postprocessing and end of postprocessing skeleton
- Add event for skeleton deletion, for cleanup
- Restrictions are applied at the end of skeleton computation as a post-process
- Provide final position/rotation of bones through read-only ITransformation
- All dependent script from ISkeleton.Transformation now use ITransformation whenever possible
- Fix Bug on BindOnController bindings that could not move because transform was never updated (value type objects)
- Add utilities to apply action recursively on a hierarchy
- Add corresponding UT