### PR TITLE
Add transition duration parameter in pose request

### DIFF
--- a/UMI3D-SDK/Assets/Tests/EditMode_Tests/Common/UserCapture/Pose/Serializer/PoseAnimationSerializerModule_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/EditMode_Tests/Common/UserCapture/Pose/Serializer/PoseAnimationSerializerModule_Test.cs
@@ -164,6 +164,7 @@ namespace EditMode_Tests.UserCapture.Pose.Common
             {
                 poseId = 1369uL,
                 stopPose = true,
+                transitionDuration = 0.56f
             };
 
             poseSerializerModule.Write(playPoseClipRequest, out Bytable data);
@@ -173,12 +174,14 @@ namespace EditMode_Tests.UserCapture.Pose.Common
             // when
             UMI3DSerializer.TryRead<uint>(byteContainer, out uint operationKey);
             poseSerializerModule.Read(byteContainer, out bool readable, out PlayPoseClipDto result);
+
             // then
             Assert.IsTrue(readable);
 
             Assert.AreEqual(UMI3DOperationKeys.PlayPoseRequest, operationKey);
             Assert.AreEqual(playPoseClipRequest.poseId, result.poseId);
             Assert.AreEqual(playPoseClipRequest.stopPose, result.stopPose);
+            Assert.AreEqual(playPoseClipRequest.transitionDuration, result.transitionDuration);
         }
 
         #endregion Read Pose Request

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Networking/UMI3DForgeClient.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Networking/UMI3DForgeClient.cs
@@ -695,10 +695,12 @@ namespace umi3d.cdk.collaboration
                     {
                         ulong poseId = UMI3DSerializer.Read<ulong>(container);
                         bool stopPose = UMI3DSerializer.Read<bool>(container);
+                        float transitionDuration = UMI3DSerializer.Read<float>(container);
                         PlayPoseClipDto playPoseDto = new PlayPoseClipDto
                         {
                             poseId = poseId,
-                            stopPose = stopPose
+                            stopPose = stopPose,
+                            transitionDuration = transitionDuration
                         };
 
                         MainThreadManager.Run(() =>

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/UserCapture/CollaborationSkeletonsManager.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/UserCapture/CollaborationSkeletonsManager.cs
@@ -463,7 +463,13 @@ namespace umi3d.cdk.collaboration.userCapture
             if (playPoseDto.stopPose)
                 skeleton.PoseSubskeleton.StopPose(pose);
             else
-                skeleton.PoseSubskeleton.StartPose(pose);
+                skeleton.PoseSubskeleton.StartPose(pose, 
+                                                   isOverriding: false,
+                                                   parameters: playPoseDto.transitionDuration < 0 ? null : new() 
+                                                   { 
+                                                       startTransitionDuration = playPoseDto.transitionDuration, 
+                                                       endTransitionDuration = playPoseDto.transitionDuration
+                                                   });
         }
 
         #endregion Pose

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/DTOs/Operations/PlayPoseClipDto.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/DTOs/Operations/PlayPoseClipDto.cs
@@ -31,5 +31,11 @@ namespace umi3d.common.userCapture.pose
         /// Is it a message to stop or to start the related pose
         /// </summary>
         public bool stopPose { get; set; }
+
+        /// <summary>
+        /// Transition duration in seconds.
+        /// </summary>
+        /// If negative, no transition duration is specified.
+        public float transitionDuration { get; set; }
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/Serializers/PoseAnimationSerializerModule.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/UserCapture/Runtime/Skeleton/Pose/Serializers/PoseAnimationSerializerModule.cs
@@ -143,13 +143,15 @@ namespace umi3d.common.userCapture.pose
                     {
                         readable = UMI3DSerializer.TryRead(container, out ulong poseId);
                         readable &= UMI3DSerializer.TryRead(container, out bool stopPose);
+                        readable &= UMI3DSerializer.TryRead(container, out float transitionDuration);
 
                         if (readable)
                         {
                             PlayPoseClipDto activatePoseOverriderDto = new()
                             {
                                 poseId = poseId,
-                                stopPose = stopPose
+                                stopPose = stopPose,
+                                transitionDuration = transitionDuration
                             };
 
                             result = (T)Convert.ChangeType(activatePoseOverriderDto, typeof(PlayPoseClipDto));
@@ -203,7 +205,8 @@ namespace umi3d.common.userCapture.pose
                 case PlayPoseClipDto playPoseAnimationDto:
                     bytable = UMI3DSerializer.Write(UMI3DOperationKeys.PlayPoseRequest)
                         + UMI3DSerializer.Write(playPoseAnimationDto.poseId)
-                        + UMI3DSerializer.Write(playPoseAnimationDto.stopPose);
+                        + UMI3DSerializer.Write(playPoseAnimationDto.stopPose)
+                        + UMI3DSerializer.Write(playPoseAnimationDto.transitionDuration);
                     break;
 
                 default:

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/UserCapture/Runtime/Pose/Operations/PlayPoseClipRequest.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/UserCapture/Runtime/Pose/Operations/PlayPoseClipRequest.cs
@@ -34,6 +34,12 @@ namespace umi3d.edk.userCapture.pose
         /// </summary>
         public bool shouldStopPose;
 
+        /// <summary>
+        /// Transition to pose duration in seconds.
+        /// </summary>
+        /// If negative, the browser will use a default value.
+        public float transitionDuration = -1f;
+
         public PlayPoseClipRequest(ulong poseId, bool stopPose = false)
         {
             this.poseId = poseId;
@@ -44,7 +50,8 @@ namespace umi3d.edk.userCapture.pose
         {
             return UMI3DSerializer.Write(GetOperationKey())
                 + UMI3DSerializer.Write(poseId)
-                + UMI3DSerializer.Write(shouldStopPose);
+                + UMI3DSerializer.Write(shouldStopPose)
+                + UMI3DSerializer.Write(transitionDuration);
         }
 
         public override AbstractOperationDto ToOperationDto(UMI3DUser user)
@@ -72,6 +79,7 @@ namespace umi3d.edk.userCapture.pose
         {
             dto.poseId = poseId;
             dto.stopPose = shouldStopPose;
+            dto.transitionDuration = transitionDuration;
         }
     }
 }


### PR DESCRIPTION
Being able to control the transition duration when a pose request is applied.

Add a transitionDuration parameter in the pose request.

Allows for instantaneous pose request. Useful for sitting pose where a teleportation is applied at the same time.