### PR TITLE
Access bone via UnityTransformation directly

### DIFF
--- a/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Tracking/Constraints/Loader/BoneConstraintLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/EditMode_Tests/CDK/UserCapture/Tracking/Constraints/Loader/BoneConstraintLoader_Test.cs
@@ -137,7 +137,7 @@ namespace EditMode_Tests.UserCapture.Tracking.Constraint.CDK
             };
 
             var personalSkeletonMock = new Mock<IPersonalSkeleton>();
-            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ITransformation>() { { dto.ConstrainingBone, new PureTransformation() } });
+            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, UnityTransformation>() { { dto.ConstrainingBone, new (new GameObject().transform) } });
 
             skeletonServiceMock.Setup(x => x.PersonalSkeleton).Returns(personalSkeletonMock.Object);
 
@@ -370,7 +370,7 @@ namespace EditMode_Tests.UserCapture.Tracking.Constraint.CDK
             environmentServiceMock.Setup(x => x.TryGetEntity(environmentId, boneBoneConstraint.Id, out boneBoneConstraint)).Returns(true);
 
             var personalSkeletonMock = new Mock<IPersonalSkeleton>();
-            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ITransformation>() { { value, new PureTransformation() } });
+            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, UnityTransformation>() { { value, new(new GameObject().transform) } });
 
             skeletonServiceMock.Setup(x => x.PersonalSkeleton).Returns(personalSkeletonMock.Object);
 

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/Binding/CollaborationBindingLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Collaboration/Binding/CollaborationBindingLoader_Test.cs
@@ -110,7 +110,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
             nodeMock.Setup(x => x.transform).Returns(nodeGameObject.transform);
 
             var skeletonMock = new Mock<ISkeleton>();
-            skeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ITransformation>() { { targetBoneType, new PureTransformation() } });
+            skeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, UnityTransformation>() { { targetBoneType, new UnityTransformation(new GameObject().transform) } });
             
             loadingManagerMock.Setup(x => x.WaitUntilNodeInstanceLoaded(environmentId, dto.boundNodeId, null)).Returns(Task.FromResult(nodeMock.Object));
             environmentManagerMock.Setup(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>())).Returns(entityFake);
@@ -189,7 +189,7 @@ namespace PlayMode_Tests.Collaboration.UserCapture.Binding.CDK
             nodeMock.Setup(x => x.transform).Returns(nodeGameObject.transform);
 
             var skeletonMock = new Mock<ISkeleton>();
-            skeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ITransformation>() { { targetBoneType, new PureTransformation() } });
+            skeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, UnityTransformation>() { { targetBoneType, new UnityTransformation(new GameObject().transform) } });
 
             loadingManagerMock.Setup(x => x.WaitUntilNodeInstanceLoaded(environmentId, dto.boundNodeId, null)).Returns(Task.FromResult(nodeMock.Object));
             environmentManagerMock.Setup(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>())).Returns(entityFake);

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/BoneBinding_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/BoneBinding_Test.cs
@@ -92,9 +92,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ITransformation>()
+            var skeletonBones = new Dictionary<uint, UnityTransformation>()
             {
-                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new UnityTransformation(new GameObject().transform) { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -129,9 +129,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ITransformation>()
+            var skeletonBones = new Dictionary<uint, UnityTransformation>()
             {
-                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new UnityTransformation(new GameObject().transform) { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -298,9 +298,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ITransformation>()
+            var skeletonBones = new Dictionary<uint, UnityTransformation>()
             {
-                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new UnityTransformation(new GameObject().transform) { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -334,9 +334,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ITransformation>()
+            var skeletonBones = new Dictionary<uint, UnityTransformation>()
             {
-                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new UnityTransformation(new GameObject().transform) { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -387,9 +387,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ITransformation>()
+            var skeletonBones = new Dictionary<uint, UnityTransformation>()
             {
-                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new UnityTransformation(new GameObject().transform) { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -424,9 +424,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ITransformation>()
+            var skeletonBones = new Dictionary<uint, UnityTransformation>()
             {
-                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new UnityTransformation(new GameObject().transform) { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/RigBoneBinding_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/RigBoneBinding_Test.cs
@@ -99,9 +99,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ITransformation>()
+            var skeletonBones = new Dictionary<uint, UnityTransformation>()
             {
-                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new UnityTransformation(new GameObject().transform) { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -136,9 +136,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ITransformation>()
+            var skeletonBones = new Dictionary<uint, UnityTransformation>()
             {
-                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new UnityTransformation(new GameObject().transform) { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -191,9 +191,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ITransformation>()
+            var skeletonBones = new Dictionary<uint, UnityTransformation>()
             {
-                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new UnityTransformation(new GameObject().transform) { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -227,9 +227,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ITransformation>()
+            var skeletonBones = new Dictionary<uint, UnityTransformation>()
             {
-                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new UnityTransformation(new GameObject().transform) { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -280,9 +280,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ITransformation>()
+            var skeletonBones = new Dictionary<uint, UnityTransformation>()
             {
-                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new UnityTransformation(new GameObject().transform) { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);
@@ -317,9 +317,9 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
 
             var skeletonBoneMock = new Mock<ISkeleton>();
 
-            var skeletonBones = new Dictionary<uint, ITransformation>()
+            var skeletonBones = new Dictionary<uint, UnityTransformation>()
             {
-                { boneType, new PureTransformation() { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
+                { boneType, new UnityTransformation(new GameObject().transform) { Position = parentGo.transform.position, Rotation= parentGo.transform.rotation } }
             };
 
             skeletonBoneMock.Setup(x => x.Bones).Returns(skeletonBones);

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/UserCaptureBindingLoader_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/Binding/UserCaptureBindingLoader_Test.cs
@@ -99,7 +99,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
             nodeMock.Setup(x => x.transform).Returns(nodeGameObject.transform);
 
             var personalSkeletonMock = new Mock<IPersonalSkeleton>();
-            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ITransformation>() { { targetBoneType, new PureTransformation() } });
+            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, UnityTransformation>() { { targetBoneType, new UnityTransformation(new GameObject().transform) } });
 
             loadingManagerMock.Setup(x => x.WaitUntilNodeInstanceLoaded(environmentId, dto.boundNodeId, null)).Returns(Task.FromResult(nodeMock.Object));
             environmentManagerMock.Setup(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>())).Returns(entityFake);
@@ -141,7 +141,7 @@ namespace PlayMode_Tests.UserCapture.Binding.CDK
             nodeMock.Setup(x => x.transform).Returns(nodeGameObject.transform);
 
             var personalSkeletonMock = new Mock<IPersonalSkeleton>();
-            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, ITransformation>() { { targetBoneType, new PureTransformation()} });
+            personalSkeletonMock.Setup(x => x.Bones).Returns(new Dictionary<uint, UnityTransformation>() { { targetBoneType, new UnityTransformation(new GameObject().transform)} });
 
             loadingManagerMock.Setup(x => x.WaitUntilNodeInstanceLoaded(environmentId, dto.boundNodeId, null)).Returns(Task.FromResult(nodeMock.Object));
             environmentManagerMock.Setup(x => x.RegisterEntity(environmentId, dto.id, dto, null, It.IsAny<System.Action>())).Returns(entityFake);

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/SubskeletonDescriptionInterpolationPlayer_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/UserCapture/SubskeletonDescriptionInterpolationPlayer_Test.cs
@@ -55,7 +55,7 @@ namespace PlayMode_Tests.UserCapture.CDK
             mockDescriptor = new();
             mockDescriptor.Setup(x => x.GetPose(It.IsAny<UMI3DSkeletonHierarchy>())).Returns(pose);
 
-            mockSkeleton.Setup(x => x.Bones).Returns(bones.ToDictionary(x => x.boneType, y => (ITransformation)new PureTransformation() { LocalRotation = Quaternion.identity, Position = Vector3.zero, Rotation = Quaternion.identity }));
+            mockSkeleton.Setup(x => x.Bones).Returns(bones.ToDictionary(x => x.boneType, y => new UnityTransformation(new GameObject().transform) { LocalRotation = Quaternion.identity, Position = Vector3.zero, Rotation = Quaternion.identity }));
 
             player = new(mockDescriptor.Object, true, mockSkeleton.Object);
         }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/AbstractSkeleton.cs
@@ -43,15 +43,13 @@ namespace umi3d.cdk.userCapture
 
         #region Fields
 
-        protected Dictionary<uint, UnityTransformation> bones = new Dictionary<uint, UnityTransformation>();
+        protected Dictionary<uint, UnityTransformation> bones = new ();
 
         /// <inheritdoc/>
-        public virtual IReadOnlyDictionary<uint, ITransformation> Bones
+        public virtual IReadOnlyDictionary<uint, UnityTransformation> Bones
         {
-            get => bones.ToDictionary(x => x.Key, y => (ITransformation)y.Value);
-            protected set => bones = value is not IDictionary<uint, ITransformation> castValue ? bones
-                                : castValue.Where(kv => kv.Value is UnityTransformation)
-                                           .ToDictionary(x => x.Key, y => (UnityTransformation)y.Value);
+            get => bones;
+            protected set => bones = value is not Dictionary<uint, UnityTransformation> castValue ? bones : castValue;
         }
 
         /// <summary>

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Interfaces/ISkeleton.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Interfaces/ISkeleton.cs
@@ -37,7 +37,7 @@ namespace umi3d.cdk.userCapture
         /// <summary>
         /// Position and rotation of each bone, indexed by UMI3D <see cref="BoneType"/>.
         /// </summary>
-        IReadOnlyDictionary<uint, ITransformation> Bones { get; }
+        IReadOnlyDictionary<uint, UnityTransformation> Bones { get; }
 
         /// <summary>
         /// Subskeletons that compose the final skeleton.

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/TrackerSimulation/Loader/BoneConstraintLoader.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Tracking/TrackerSimulation/Loader/BoneConstraintLoader.cs
@@ -79,7 +79,7 @@ namespace umi3d.cdk.userCapture.tracking.constraint
                     }
                 case BoneBoneConstraintDto boneBoneConstraintDto:
                     {
-                        if (!skeletonService.PersonalSkeleton.Bones.TryGetValue(boneBoneConstraintDto.ConstrainingBone, out ITransformation boneReference))
+                        if (!skeletonService.PersonalSkeleton.Bones.TryGetValue(boneBoneConstraintDto.ConstrainingBone, out UnityTransformation boneReference))
                         {
                             await Task.Run(() => UMI3DLogger.LogWarning($"Bone {boneBoneConstraintDto.ConstrainingBone} not found for applying BoneBone constraint.", DEBUG_SCOPE));
                             break;
@@ -221,7 +221,7 @@ namespace umi3d.cdk.userCapture.tracking.constraint
             if (!environmentService.TryGetEntity(environmentId, entityId, out BoneBoneConstraint boneConstraint))
                 return;
 
-            if (!skeletonService.PersonalSkeleton.Bones.TryGetValue(bone, out ITransformation boneReference))
+            if (!skeletonService.PersonalSkeleton.Bones.TryGetValue(bone, out UnityTransformation boneReference))
                 return;
 
             boneConstraint.ConstrainingBoneTransform = boneReference;


### PR DESCRIPTION
Fix lags when accessing bones because was creating a new dictionnary eahc time.
Fixed by accessing directly the UnityTransformation.