### PR TITLE
Bug/bug 9521 emote unavailable creates nullref

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/Emotes/Objects/UMI3DEmote.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/Emotes/Objects/UMI3DEmote.cs
@@ -39,7 +39,7 @@ namespace umi3d.edk.collaboration.emotes
         /// <summary>
         /// Emote animation
         /// </summary>
-        public UMI3DAsyncProperty<ulong> AnimationId
+        public virtual UMI3DAsyncProperty<ulong> AnimationId
         {
             get
             {
@@ -54,7 +54,7 @@ namespace umi3d.edk.collaboration.emotes
         /// <summary>
         /// If the user can see and play the emote.
         /// </summary>
-        public UMI3DAsyncProperty<bool> Available
+        public virtual UMI3DAsyncProperty<bool> Available
         {
             get
             {

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/Emotes/Services/EmoteDispatcher.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/Emotes/Services/EmoteDispatcher.cs
@@ -178,7 +178,7 @@ namespace umi3d.edk.collaboration.emotes
             
             if (animationId != default) // when animationId is default, trigger emote without triggering an animation
             {
-                UMI3DAbstractAnimation animation = umi3dEnvironmentService._GetEntityInstance<UMI3DAbstractAnimation>(animationId);
+                IAnimation animation = umi3dEnvironmentService._GetEntityInstance<IAnimation>(animationId);
 
                 if (animation == null)
                 {

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/Emotes/Services/EmoteDispatcher.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/Emotes/Services/EmoteDispatcher.cs
@@ -94,6 +94,7 @@ namespace umi3d.edk.collaboration.emotes
             if (!AutoLoadAnimations)
                 return;
 
+            // retrieve animations for each emote and their loading operation
             var operations = (from otherUser in umi3dServerService.Users()
                               where otherUser.Id() != user.Id() && EmotesConfigs.ContainsKey(otherUser.Id())
                               from emote in EmotesConfigs[otherUser.Id()].IncludedEmotes
@@ -108,7 +109,7 @@ namespace umi3d.edk.collaboration.emotes
 
             Transaction t = new() { reliable = true };
             t.AddIfNotNull(operations);
-            t.Dispatch();
+            umi3dServerService.DispatchTransaction(t);
         }
 
         private void CleanEmotesAnimations(UMI3DUser user)
@@ -128,7 +129,7 @@ namespace umi3d.edk.collaboration.emotes
 
             Transaction t = new() { reliable = true };
             t.AddIfNotNull(operations);
-            t.Dispatch();
+            umi3dServerService.DispatchTransaction(t);
         }
 
         /// <summary>
@@ -139,19 +140,33 @@ namespace umi3d.edk.collaboration.emotes
         /// <param name="trigger">True for triggering, false to interrupt.</param>
         public void DispatchEmoteTrigger(UMI3DUser sendingUser, ulong emoteId, bool trigger)
         {
+            // lots of null handling here, but emote request can be invalid in many ways.
+            /* to be valid :
+             * An emote config should exist for the user, 
+             * it should the required emote,
+             * the emote should be available for the user,
+             * and the emote animation should not have been destroyed in the meanwhile.
+            */
+
             ulong sendingUserId = sendingUser.Id();
             if (!EmotesConfigs.ContainsKey(sendingUserId))
             {
-                UMI3DLogger.LogWarning($"Cannot {(trigger ? "start" : "stop")} emote for user {sendingUserId}. User does not have an emote config.", DEBUG_SCOPE);
+                UMI3DLogger.LogWarning($"Cannot {(trigger ? "start" : "stop")} emote for user {sendingUserId}. User does not have an emote config. User {sendingUserId} should not be able to request emotes.", DEBUG_SCOPE);
                 return;
             }
             else if (EmotesConfigs[sendingUserId].IncludedEmotes.Count == 0)
             {
-                UMI3DLogger.LogWarning($"Cannot {(trigger ? "start" : "stop")} emote for user {sendingUserId}. Emote config is empty of emotes.", DEBUG_SCOPE);
+                UMI3DLogger.LogWarning($"Cannot {(trigger ? "start" : "stop")} emote for user {sendingUserId}. Emote config is empty of emotes. User {sendingUserId} should not be able to request emotes.", DEBUG_SCOPE);
                 return;
             }
 
             UMI3DEmote emote = EmotesConfigs[sendingUserId].IncludedEmotes.Find(x => x.Id() == emoteId);
+
+            if (emote == null)
+            {
+                UMI3DLogger.LogWarning($"Cannot {(trigger ? "start" : "stop")} emote for user {sendingUserId}. Emote {emoteId} does not exist. Emote request is invalid or emote config has been reset.", DEBUG_SCOPE);
+                return;
+            }
 
             if (!emote.Available.GetValue(sendingUser))
             {
@@ -164,10 +179,17 @@ namespace umi3d.edk.collaboration.emotes
             if (animationId != default) // when animationId is default, trigger emote without triggering an animation
             {
                 UMI3DAbstractAnimation animation = umi3dEnvironmentService._GetEntityInstance<UMI3DAbstractAnimation>(animationId);
+
+                if (animation == null)
+                {
+                    UMI3DLogger.LogWarning($"Cannot {(trigger ? "start" : "stop")} emote for user {sendingUserId}. Associated animation {animationId} for emote {emote.label} does not exist. Animation {animationId} may have been destroyed.", DEBUG_SCOPE);
+                    return;
+                }
+
                 Transaction t = new (true);
                 SetEntityProperty op = animation.objectPlaying.SetValue(trigger);
                 if (t.AddIfNotNull(op))
-                    t.Dispatch();
+                    umi3dServerService.DispatchTransaction(t);
             }
 
             EmoteTriggered?.Invoke((sendingUser, emoteId, trigger));

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Multi User/UMI3DAsyncProperty.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Multi User/UMI3DAsyncProperty.cs
@@ -177,7 +177,7 @@ namespace umi3d.edk
         /// </summary>
         /// <param name="user">the user</param>
         /// <returns></returns>
-        public T GetValue(UMI3DUser user)
+        public virtual T GetValue(UMI3DUser user)
         {
             if (user == null)
                 return value;
@@ -189,7 +189,7 @@ namespace umi3d.edk
         /// </summary>
         /// <param name="user">the user</param>
         /// <returns></returns>
-        public T GetValue()
+        public virtual T GetValue()
         {
             return value;
         }
@@ -199,7 +199,7 @@ namespace umi3d.edk
         /// </summary>
         /// <param name="value">the new property's value</param>
         /// <param name="forceOperation">state if an operation should be return even if the new value is equal to the previous value</param>
-        public SetEntityProperty SetValue(T value, bool forceOperation = false)
+        public virtual SetEntityProperty SetValue(T value, bool forceOperation = false)
         {
             if (((this.value == null && value == null) || (this.value != null && Equal(this.value, value))) && !forceOperation)
                 return null;
@@ -223,7 +223,7 @@ namespace umi3d.edk
         /// <param name="user">the user</param>
         /// <param name="value">the new property's value</param>
         /// <param name="forceOperation">state if an operation should be return even if the new value is equal to the previous value</param>
-        public SetEntityProperty SetValue(UMI3DUser user, T value, bool forceOperation = false)
+        public virtual SetEntityProperty SetValue(UMI3DUser user, T value, bool forceOperation = false)
         {
             if (user == null)
                 return SetValue(value, forceOperation);

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/Animation/AbstractUMI3DAnimation.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/Animation/AbstractUMI3DAnimation.cs
@@ -25,13 +25,13 @@ namespace umi3d.edk
     /// <summary>
     /// Abstract base for all animated media, such as animations, videoplayers or audioplayers.
     /// </summary>
-    public class UMI3DAbstractAnimation : MonoBehaviour, UMI3DLoadableEntity
+    public class UMI3DAbstractAnimation : MonoBehaviour, UMI3DLoadableEntity, IAnimation
     {
         /// <summary>
         /// Entity UMI3D id.
         /// </summary>
         private ulong animationID;
-        
+
         /// <summary>
         /// Is the animation playing?
         /// </summary>
@@ -147,7 +147,7 @@ namespace umi3d.edk
         }
 
         /// <inheritdoc/>
-        public DeleteEntity GetDeleteEntity(HashSet<UMI3DUser> users = null)
+        public virtual DeleteEntity GetDeleteEntity(HashSet<UMI3DUser> users = null)
         {
             var operation = new DeleteEntity()
             {
@@ -176,7 +176,7 @@ namespace umi3d.edk
         /// </summary>
         /// <param name="user">User to convert for</param>
         /// <returns></returns>
-        public UMI3DAbstractAnimationDto ToAnimationDto(UMI3DUser user)
+        public virtual UMI3DAbstractAnimationDto ToAnimationDto(UMI3DUser user)
         {
             UMI3DAbstractAnimationDto dto = CreateDto();
             WriteProperties(dto, user);
@@ -193,13 +193,13 @@ namespace umi3d.edk
         }
 
         /// <inheritdoc/>
-        public IEntity ToEntityDto(UMI3DUser user)
+        public virtual IEntity ToEntityDto(UMI3DUser user)
         {
             return ToAnimationDto(user);
         }
 
         /// <inheritdoc/>
-        public Bytable ToBytes(UMI3DUser user)
+        public virtual Bytable ToBytes(UMI3DUser user)
         {
             return UMI3DSerializer.Write(Id())
                 + UMI3DSerializer.Write(objectPlaying.GetValue(user))

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/Animation/IAnimation.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/Animation/IAnimation.cs
@@ -1,0 +1,48 @@
+﻿/*
+Copyright 2019 - 2021 Inetum
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using umi3d.common;
+
+namespace umi3d.edk
+{
+    /// <summary>
+    /// Behaviours for all animated media, such as animations, videoplayers or audioplayers
+    /// </summary>
+    public interface IAnimation : UMI3DEntity
+    {
+        /// <summary>
+        /// Should the animation start again when reaching its end?
+        /// </summary>
+        UMI3DAsyncProperty<bool> objectLooping { get; }
+
+        /// <summary>
+        /// Animation last pause time in milliseconds.
+        /// </summary>
+        UMI3DAsyncProperty<long> objectPauseTime { get; }
+
+        /// <summary>
+        /// Is the animation playing?
+        /// </summary>
+        UMI3DAsyncProperty<bool> objectPlaying { get; }
+
+        /// <summary>
+        /// Animation last pause time in milliseconds.
+        /// </summary>
+        UMI3DAsyncProperty<ulong> objectStartTime { get; }
+
+        UMI3DAbstractAnimationDto ToAnimationDto(UMI3DUser user);
+    }
+}

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/Animation/IAnimation.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/Animation/IAnimation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9e3c9be992597b348a51cce65fd1a240
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
When emote requests are received with incoherent parameters, logs a warning instead of crashing through nullref.

This PR also adds some minor test utilities, because tests associated with EmoteDispatcher were updated and required some mocking abilities.