### PR TITLE
Feature/us 9620 reset bindings when removed

### DIFF
--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Core/Binding/BindingManager_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Core/Binding/BindingManager_Test.cs
@@ -233,7 +233,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
         };
 
         [Test]
-        public void BindingRoutine([ValueSource("values")] (ulong id, int priority, bool partialFit)[] testValues)
+        public void BindingRoutine([ValueSource(nameof(values))] (ulong id, int priority, bool partialFit)[] testValues)
         {
             // GIVEN
             Queue<ulong> executionTracker = new();

--- a/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Core/Binding/NodeBinding_Test.cs
+++ b/UMI3D-SDK/Assets/Tests/PlayMode_Tests/CDK/Core/Binding/NodeBinding_Test.cs
@@ -76,7 +76,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
 
         #region Position
         [Test]
-        public void Apply_SyncPosition([ValueSource("positionOffsets")] Vector3 offSetPosition)
+        public void Apply_SyncPosition([ValueSource(nameof(positionOffsets))] Vector3 offSetPosition)
         {
             // GIVEN
             var dto = new NodeBindingDataDto()
@@ -106,7 +106,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
         }
 
         [UnityTest]
-        public IEnumerator Apply_SyncPosition_SeveralFrames([ValueSource("positionOffsets")] Vector3 offSetPosition)
+        public IEnumerator Apply_SyncPosition_SeveralFrames([ValueSource(nameof(positionOffsets))] Vector3 offSetPosition)
         {
             // GIVEN
             var dto = new NodeBindingDataDto()
@@ -150,7 +150,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
         #region Rotation
 
         [Test]
-        public void Apply_SyncRotation([ValueSource("rotationOffsets")] Quaternion offsetRotation)
+        public void Apply_SyncRotation([ValueSource(nameof(rotationOffsets))] Quaternion offsetRotation)
         {
             // GIVEN
 
@@ -182,7 +182,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
         }
 
         [UnityTest]
-        public IEnumerator Apply_SyncRotation_SeveralFrames([ValueSource("rotationOffsets")] Quaternion offsetRotation)
+        public IEnumerator Apply_SyncRotation_SeveralFrames([ValueSource(nameof(rotationOffsets))] Quaternion offsetRotation)
         {
             // GIVEN
 
@@ -229,7 +229,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
         #region Scale
 
         [Test]
-        public void Apply_SyncScale([ValueSource("scaleOffsets")] Vector3 offSetScale)
+        public void Apply_SyncScale([ValueSource(nameof(scaleOffsets))] Vector3 offSetScale)
         {
             // GIVEN
             var dto = new NodeBindingDataDto()
@@ -260,7 +260,7 @@ namespace PlayMode_Tests.Core.Binding.CDK
         }
 
         [UnityTest]
-        public IEnumerator Apply_SyncScale_SeveralFrames([ValueSource("scaleOffsets")] Vector3 offSetScale)
+        public IEnumerator Apply_SyncScale_SeveralFrames([ValueSource(nameof(scaleOffsets))] Vector3 offSetScale)
         {
             // GIVEN
             var dto = new NodeBindingDataDto()
@@ -302,5 +302,47 @@ namespace PlayMode_Tests.Core.Binding.CDK
         #endregion Scale
 
         #endregion Apply
+
+        #region Reset
+
+        [Test, TestOf(nameof(NodeBinding.Reset))]
+        public void Reset()
+        {
+            // GIVEN
+            var dto = new NodeBindingDataDto()
+            {
+                parentNodeId = 1008uL,
+                syncPosition = true,
+                offSetPosition = Vector3.one.Dto(),
+                syncRotation = true,
+                offSetRotation = Quaternion.Euler(0,90,0).Dto(),
+                syncScale = true,
+                offSetScale = (Vector3.one * 2).Dto(),
+                resetWhenRemoved = true,
+            };
+
+            var parentNodeMock = new Mock<UMI3DNodeInstance>(MockBehavior.Default, UMI3DGlobalID.EnvironmentId, new System.Action(() => { }), dto.parentNodeId);
+
+            parentNodeMock.Setup(x => x.transform).Returns(parentGo.transform);
+
+            NodeBinding binding = new(dto, go.transform, parentNodeMock.Object);
+
+            Vector3 previousPosition = go.transform.position;
+            Quaternion previousRotation = go.transform.rotation;
+            Vector3 previousScale = go.transform.localScale;
+
+            binding.Apply(out bool succes);
+
+            // WHEN
+            binding.Reset();
+
+            // THEN
+            Assert.IsTrue(succes);
+            AssertUnityStruct.AreEqual(previousPosition, go.transform.position, message: "Positions are not equal");
+            AssertUnityStruct.AreEqual(previousRotation, go.transform.rotation, message: "Rotations are not the same.");
+            AssertUnityStruct.AreEqual(previousScale, go.transform.localScale, message: "Scales are not the same.");
+        }
+
+        #endregion Reset
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Loader/BindingLoader.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Loader/BindingLoader.cs
@@ -77,6 +77,8 @@ namespace umi3d.cdk.binding
 
             bindingManagementService.AddBinding(value.environmentId,dto.boundNodeId, binding);
 
+            bindingManagementService.ForceBindingsApplicationUpdate();
+
             void onDelete() { bindingManagementService.RemoveBinding(value.environmentId,dto.boundNodeId); }
             environmentManager.RegisterEntity(value.environmentId, dto.id, dto, null, onDelete).NotifyLoaded();
         }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/AbstractBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/AbstractBinding.cs
@@ -47,9 +47,14 @@ namespace umi3d.cdk.binding
         public virtual int Priority => data.priority;
 
         /// <summary>
+        /// See <see cref="AbstractBindingDataDto.resetWhenRemoved"/>.
+        /// </summary>
+        public virtual bool ResetWhenRemoved => data.resetWhenRemoved;
+
+        /// <summary>
         /// Transform of the bound node.
         /// </summary>
-        public virtual Transform BoundTransform => boundTransform;
+        public virtual Transform BoundTransform => boundTransform;  
 
         #endregion DTO Access
 
@@ -64,5 +69,10 @@ namespace umi3d.cdk.binding
         /// </summary>
         /// <param name="success"></param>
         public abstract void Apply(out bool success);
+
+        /// <summary>
+        /// Put back the bound object at its original world place.
+        /// </summary>
+        public abstract void Reset();
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/AbstractSimpleBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/AbstractSimpleBinding.cs
@@ -133,8 +133,15 @@ namespace umi3d.cdk.binding
             if (boundTransform == null) // object destroyed before binding reset
                 return;
 
-            boundTransform.SetLocalPositionAndRotation(OriginalTransformation.LocalPosition, OriginalTransformation.LocalRotation);
-            boundTransform.localScale = OriginalTransformation.Scale;
+            if (SyncPosition && SyncRotation)
+                boundTransform.SetLocalPositionAndRotation(OriginalTransformation.LocalPosition, OriginalTransformation.LocalRotation);
+            else if (SyncPosition)
+                boundTransform.localPosition = OriginalTransformation.LocalPosition;
+            else if (SyncRotation)
+                boundTransform.localRotation = OriginalTransformation.LocalRotation;
+
+            if (SyncScale)
+                boundTransform.localScale = OriginalTransformation.Scale;
         }
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/NodeBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/NodeBinding.cs
@@ -54,6 +54,9 @@ namespace umi3d.cdk.binding
                 return;
             }
 
+            if (!hasStartedToBeApplied)
+                Start();
+
             Compute((parentNode.transform.position, parentNode.transform.rotation, parentNode.transform.localScale));
             success = true;
         }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/RigNodeBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/RigNodeBinding.cs
@@ -29,7 +29,7 @@ namespace umi3d.cdk.binding
         public RigNodeBinding(RigNodeBindingDataDto dto, Transform boundTransform, UMI3DNodeInstance parentNode, Transform rootObject) : base(dto, boundTransform, parentNode)
         {
             this.rootObject = rootObject;
-            this.autoComputedRotationOffset = Quaternion.Inverse(rootObject.rotation) * boundTransform.rotation;
+            this.autoComputedRotationOffset = Quaternion.Inverse(rootObject.rotation) * boundTransform.rotation; // local in the parent referential
         }
 
         protected RigNodeBindingDataDto RigNodeBindingDataDto => SimpleBindingData as RigNodeBindingDataDto;

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/RigNodeBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Objects/RigNodeBinding.cs
@@ -29,7 +29,7 @@ namespace umi3d.cdk.binding
         public RigNodeBinding(RigNodeBindingDataDto dto, Transform boundTransform, UMI3DNodeInstance parentNode, Transform rootObject) : base(dto, boundTransform, parentNode)
         {
             this.rootObject = rootObject;
-            this.originalRotationOffset = Quaternion.Inverse(rootObject.rotation) * boundTransform.rotation;
+            this.autoComputedRotationOffset = Quaternion.Inverse(rootObject.rotation) * boundTransform.rotation;
         }
 
         protected RigNodeBindingDataDto RigNodeBindingDataDto => SimpleBindingData as RigNodeBindingDataDto;
@@ -58,6 +58,9 @@ namespace umi3d.cdk.binding
                 success = false;
                 return;
             }
+
+            if (!hasStartedToBeApplied)
+                Start();
 
             Compute((parentNode.transform.position, parentNode.transform.rotation, parentNode.transform.localScale));
             success = true;

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Service/BindingManager.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Service/BindingManager.cs
@@ -163,8 +163,13 @@ namespace umi3d.cdk.binding
         public virtual void RemoveBinding(ulong environmentId, ulong boundNodeId)
         {
             var key = (environmentId, boundNodeId);
-            if (bindings.ContainsKey(key))
+            if (bindings.TryGetValue(key, out AbstractBinding bindingToRemove))
             {
+                if (bindingToRemove is not null && bindingToRemove.ResetWhenRemoved)
+                {
+                    bindingToRemove.Reset();
+                }
+
                 bindings.Remove(key);
                 ReorderQueue();
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Service/IBindingBrowserService.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Binding/Service/IBindingBrowserService.cs
@@ -31,7 +31,7 @@ namespace umi3d.cdk.binding
         /// <summary>
         /// Currently computed bindings per UMI3D node id.
         /// </summary>
-        public IReadOnlyDictionary<(ulong,ulong), AbstractBinding> Bindings { get; }
+        public IReadOnlyDictionary<(ulong environmentId, ulong nodeId), AbstractBinding> Bindings { get; }
 
         /// <summary>
         /// Add a binding that already has been loaded.
@@ -45,6 +45,11 @@ namespace umi3d.cdk.binding
         /// </summary>
         /// <param name="boundNodeid">Id of the node that is bound.</param>
         public void RemoveBinding(ulong environmentId, ulong boundNodeid);
+
+        /// <summary>
+        /// Force the update of the binding application coroutine.
+        /// </summary>
+        void ForceBindingsApplicationUpdate();
 
         /// <summary>
         /// Enable/disable bindings computation for this client.

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Binding/Objects/BoneBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Binding/Objects/BoneBinding.cs
@@ -68,6 +68,9 @@ namespace umi3d.cdk.userCapture.binding
                 return;
             }
 
+            if (!hasStartedToBeApplied)
+                Start();
+
             ITransformation parentBone = null;
 
             if (BindToController && skeleton.TrackedSubskeleton.Controllers.TryGetValue(BoneType, out IController controller))

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Binding/Objects/RigBoneBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Binding/Objects/RigBoneBinding.cs
@@ -29,7 +29,7 @@ namespace umi3d.cdk.userCapture.binding
                     : base(dto, rigBoundTransform, skeleton)
         {
             this.rootObject = rootObject;
-            this.autoComputedRotationOffset = UseAutoComputedRotationOffset ? Quaternion.Inverse(rootObject.rotation) * boundTransform.rotation : Quaternion.identity;
+            this.autoComputedRotationOffset = UseAutoComputedRotationOffset ? Quaternion.Inverse(rootObject.rotation) * rigBoundTransform.rotation : Quaternion.identity;
         }
 
         #region DTO Access

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Binding/Objects/RigBoneBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/UserCapture/Runtime/Skeleton/Binding/Objects/RigBoneBinding.cs
@@ -14,9 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-using System.Linq;
-using umi3d.cdk.userCapture.tracking;
-using umi3d.common;
+using umi3d.common.core;
 using umi3d.common.userCapture.binding;
 using UnityEngine;
 
@@ -27,10 +25,11 @@ namespace umi3d.cdk.userCapture.binding
     /// </summary>
     public class RigBoneBinding : BoneBinding
     {
-        public RigBoneBinding(RigBoneBindingDataDto dto, Transform rigBoundTransform, ISkeleton skeleton, Transform rootObject) : base(dto, rigBoundTransform, skeleton)
+        public RigBoneBinding(RigBoneBindingDataDto dto, Transform rigBoundTransform, ISkeleton skeleton, Transform rootObject)
+                    : base(dto, rigBoundTransform, skeleton)
         {
-            this.rootObject = rootObject;      
-            this.originalRotationOffset = ApplyOriginalRotation ? Quaternion.Inverse(rootObject.rotation) * boundTransform.rotation : Quaternion.identity;
+            this.rootObject = rootObject;
+            this.autoComputedRotationOffset = UseAutoComputedRotationOffset ? Quaternion.Inverse(rootObject.rotation) * boundTransform.rotation : Quaternion.identity;
         }
 
         #region DTO Access
@@ -47,7 +46,7 @@ namespace umi3d.cdk.userCapture.binding
         /// <summary>
         /// See <see cref="RigBoneBindingDataDto.applyOriginalRotation"/>.
         /// </summary>
-        public bool ApplyOriginalRotation => RigBoneBindingDataDto.applyOriginalRotation;
+        public bool UseAutoComputedRotationOffset => RigBoneBindingDataDto.applyOriginalRotation;
 
 
         #endregion DTO Access

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Dto/Binding/BindingData/AbstractBindingDataDto.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Dto/Binding/BindingData/AbstractBindingDataDto.cs
@@ -32,5 +32,10 @@ namespace umi3d.common.dto.binding
         /// State if the binding can be applied partialy or not. A partial fit can happen in MultyBinding when it's not the binding with the highest priority.
         /// </summary>
         public bool partialFit { get; set; }
+
+        /// <summary>
+        /// If true, the changes implied by the binding are reset when the binding is destroyed.
+        /// </summary>
+        public bool resetWhenRemoved { get; set; } = false;
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Utils/ITransformation.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Utils/ITransformation.cs
@@ -62,6 +62,18 @@ namespace umi3d.common.core
         public Quaternion LocalRotation { get; set; } = Quaternion.identity;
 
         public Vector3 Scale { get; set; } = Vector3.one;
+
+        public static PureTransformation CopyTransform(Transform transform)
+        {
+            return new PureTransformation()
+            {
+                Position = transform.position,
+                Rotation = transform.rotation,
+                LocalPosition = transform.localPosition,
+                LocalRotation = transform.localRotation,
+                Scale = transform.localScale
+            };
+        }
     }
 
     /// <summary>

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Utils/ITransformation.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Utils/ITransformation.cs
@@ -37,6 +37,11 @@ namespace umi3d.common.core
         public Quaternion LocalRotation { get; set; }
 
         /// <summary>
+        /// Position relative to parent.
+        /// </summary>
+        public Vector3 LocalPosition { get; set; }
+
+        /// <summary>
         /// Scale relative to parent.
         /// </summary>
         public Vector3 Scale { get; set; }
@@ -49,6 +54,8 @@ namespace umi3d.common.core
     public class PureTransformation : ITransformation
     {
         public Vector3 Position { get; set; } = Vector3.zero;
+
+        public Vector3 LocalPosition { get; set; } = Vector3.zero;
 
         public Quaternion Rotation { get; set; } = Quaternion.identity;
 
@@ -72,6 +79,12 @@ namespace umi3d.common.core
         {
             get => Transform.rotation;
             set => Transform.rotation = value;
+        }
+
+        public Vector3 LocalPosition
+        {
+            get => Transform.localPosition;
+            set => Transform.localPosition = value;
         }
 
         public Quaternion LocalRotation

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene synchronisation/Binding/Objects/AbstractBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene synchronisation/Binding/Objects/AbstractBinding.cs
@@ -38,6 +38,11 @@ namespace umi3d.edk.binding
         /// </summary>
         public int priority = 0;
 
+        /// <summary>
+        /// If true, the changes implied by the binding are reset when the binding is destroyed.
+        /// </summary>
+        public bool resetWhenRemoved = false;
+
         public AbstractBinding(ulong boundNodeId) : base()
         {
             this.boundNodeId = boundNodeId;

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene synchronisation/Binding/Objects/MultiBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene synchronisation/Binding/Objects/MultiBinding.cs
@@ -45,6 +45,7 @@ namespace umi3d.edk.binding
             {
                 Bindings = bindings.Select(x => (x.ToEntityDto(user) as BindingDto).data as AbstractSimpleBindingDataDto).ToArray(),
                 priority = priority,
+                resetWhenRemoved = resetWhenRemoved,
                 partialFit = partialFit
             };
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene synchronisation/Binding/Objects/NodeBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene synchronisation/Binding/Objects/NodeBinding.cs
@@ -51,6 +51,7 @@ namespace umi3d.edk.binding
                 syncPosition = syncPosition,
                 syncRotation = syncRotation,
                 syncScale = syncScale,
+                resetWhenRemoved = resetWhenRemoved,
                 anchorPosition = anchor.Dto()
             };
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene synchronisation/Binding/Objects/RigNodeBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene synchronisation/Binding/Objects/RigNodeBinding.cs
@@ -51,6 +51,7 @@ namespace umi3d.edk.binding
                 syncRotation = syncRotation,
                 syncScale = syncScale,
                 anchorPosition = anchor.Dto(),
+                resetWhenRemoved = resetWhenRemoved,
                 rigName = rigName
             };
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/UserCapture/Runtime/Binding/Objects/BoneBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/UserCapture/Runtime/Binding/Objects/BoneBinding.cs
@@ -73,6 +73,7 @@ namespace umi3d.edk.userCapture.binding
 
                 partialFit = partialFit,
                 priority = priority,
+                resetWhenRemoved = resetWhenRemoved,
 
                 syncPosition = syncPosition,
                 syncRotation = syncRotation,

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/UserCapture/Runtime/Binding/Objects/RigBoneBinding.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/UserCapture/Runtime/Binding/Objects/RigBoneBinding.cs
@@ -60,6 +60,7 @@ namespace umi3d.edk.userCapture.binding
 
                 partialFit = partialFit,
                 priority = priority,
+                resetWhenRemoved = resetWhenRemoved,
 
                 syncPosition = syncPosition,
                 syncRotation = syncRotation,


### PR DESCRIPTION
- Add a new option in bindings to put back automatically the bound object at its original local transformation after removing the binding
- Force an application of binding at every load of a new binding to apply them immediately
- Minor readability changes

Required to be able to remove avatar bindings with specific and unknown offsets at runtime, e.g. from external non-standard format providers.



