### PR TITLE
Feature/support layout groups in UI

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/UI/Helper.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/UI/Helper.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d385e34de39dde4687b96e424563841
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/UI/Helper/UIDynamicLayoutUpdater.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/UI/Helper/UIDynamicLayoutUpdater.cs
@@ -1,0 +1,72 @@
+﻿/*
+Copyright 2019 - 2024 Inetum
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using System.Collections;
+
+using UnityEngine;
+
+namespace umi3d.edk
+{
+    /// <summary>
+    /// Update components on a dynamically managed layout.
+    /// </summary>
+    /// Add this component on the top of a hierarchy that contains a layoutGroup.
+    /// Related to a issue of Unity LayoutGroup that are totally defined only two frames after start.
+    [RequireComponent(typeof(UIRect))]
+    public class UIDynamicLayoutUpdater : MonoBehaviour
+    {
+        private void Start()
+        {
+            UpdateDynamicLayoutProperties();
+        }
+
+        /// <summary>
+        /// Update components on a dynamically managed layout.
+        /// </summary>
+        public void UpdateDynamicLayoutProperties()
+        {
+            var rectLayouts = GetComponentsInChildren<UIRect>();
+
+            foreach (var layout in rectLayouts)
+            {
+                layout.useLayoutGrouping = true;
+            }
+
+            // layout groups are initialized 2 frames after start
+            StartCoroutine(WaitForLayoutGroupInitialization(rectLayouts));
+        }
+
+        private IEnumerator WaitForLayoutGroupInitialization(UIRect[] rectLayouts)
+        {
+            foreach (var layout in rectLayouts)
+            {
+                int startingFrame = Time.frameCount;
+                yield return new WaitUntil(() => Time.frameCount > startingFrame + 2);
+                layout.objectPosition.SetValue(layout.rectTransform.localPosition);
+                layout.AnchoredPosition.SetValue(layout.rectTransform.anchoredPosition);
+                layout.AnchoredPosition.SetValue(layout.rectTransform.anchoredPosition);
+                layout.AnchoredPosition.SetValue(layout.rectTransform.anchoredPosition);
+                layout.AnchoredPosition3D.SetValue(layout.rectTransform.anchoredPosition3D);
+                layout.AnchorMin.SetValue(layout.rectTransform.anchorMin);
+                layout.AnchorMax.SetValue(layout.rectTransform.anchorMax);
+                layout.Pivot.SetValue(layout.rectTransform.pivot);
+                layout.OffsetMax.SetValue(layout.rectTransform.offsetMax);
+                layout.OffsetMin.SetValue(layout.rectTransform.offsetMin);
+                layout.SizeDelta.SetValue(layout.rectTransform.sizeDelta);
+            }
+        }
+    }
+}

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/UI/Helper/UIDynamicLayoutUpdater.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/UI/Helper/UIDynamicLayoutUpdater.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95ae1e1e1289f8044aebd73fc834c870
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: b6f1258ff1845f047b02ee35bba90649, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/UI/UIRect.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/UI/UIRect.cs
@@ -30,44 +30,53 @@ namespace umi3d.edk
         /// Pivot position relative to the anchor.
         /// </summary>
         private Vector2 anchoredPosition => GetComponent<RectTransform>().anchoredPosition;
+        private Vector2 anchoredPosition => rectTransform.anchoredPosition;
 
         /// <summary>
         /// 3D pivot position relative to the anchor.
         /// </summary>
         private Vector3 anchoredPosition3D => GetComponent<RectTransform>().anchoredPosition3D;
+        private Vector3 anchoredPosition3D => rectTransform.anchoredPosition3D;
 
         /// <summary>
         /// Normalized position of the upper right corner in the parent UIRect.
         /// </summary>
         private Vector2 anchorMax => GetComponent<RectTransform>().anchorMax;
+        private Vector2 anchorMax => rectTransform.anchorMax;
 
         /// <summary>
         /// NNormalized position of the lower left corner in the parent UIRect.
         /// </summary>
         private Vector2 anchorMin => GetComponent<RectTransform>().anchorMin;
+        private Vector2 anchorMin => rectTransform.anchorMin;
 
         /// <summary>
         /// Distance between the upper right corner of this rectangle and the upper right anchor.
         /// </summary>
         private Vector2 offsetMax => GetComponent<RectTransform>().offsetMax;
+        private Vector2 offsetMax => rectTransform.offsetMax;
 
         /// <summary>
         /// Distance between the lower left corner of this rectangle and the lower left anchor.
         /// </summary>
         private Vector2 offsetMin => GetComponent<RectTransform>().offsetMin;
+        private Vector2 offsetMin => rectTransform.offsetMin;
 
         /// <summary>
         /// Pivot point.
         /// </summary>
         private Vector2 pivot => GetComponent<RectTransform>().pivot;
+        private Vector2 pivot => rectTransform.pivot;
 
         /// <summary>
         /// Relative size of the rectangle relative to the distance between upper right and lower left anchors.
         /// </summary>
         private Vector2 sizeDelta => GetComponent<RectTransform>().sizeDelta;
+        private Vector2 sizeDelta => rectTransform.sizeDelta;
 
         private bool rectMask => GetComponent<RectMask2D>() != null;
 
+        protected internal RectTransform rectTransform;
 
         ///<see cref="anchoredPosition"/>
         public UMI3DAsyncProperty<Vector2> AnchoredPosition { get { Register(); return _anchoredPosition; } protected set => _anchoredPosition = value; }
@@ -114,6 +123,9 @@ namespace umi3d.edk
         protected override void InitDefinition(ulong id)
         {
             base.InitDefinition(id);
+
+            rectTransform = GetComponent<RectTransform>();
+
             AnchoredPosition = new UMI3DAsyncProperty<Vector2>(objectId, UMI3DPropertyKeys.AnchoredPosition, anchoredPosition, ToUMI3DSerializable.ToSerializableVector2, equality.Vector2Equality);
             AnchoredPosition3D = new UMI3DAsyncProperty<Vector3>(objectId, UMI3DPropertyKeys.AnchoredPosition3D, anchoredPosition3D, ToUMI3DSerializable.ToSerializableVector3, equality.Vector3Equality);
             AnchorMax = new UMI3DAsyncProperty<Vector2>(objectId, UMI3DPropertyKeys.AnchorMax, anchorMax, ToUMI3DSerializable.ToSerializableVector2, equality.Vector2Equality);

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/UI/UIRect.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/UI/UIRect.cs
@@ -29,54 +29,54 @@ namespace umi3d.edk
         /// <summary>
         /// Pivot position relative to the anchor.
         /// </summary>
-        private Vector2 anchoredPosition => GetComponent<RectTransform>().anchoredPosition;
         private Vector2 anchoredPosition => rectTransform.anchoredPosition;
 
         /// <summary>
         /// 3D pivot position relative to the anchor.
         /// </summary>
-        private Vector3 anchoredPosition3D => GetComponent<RectTransform>().anchoredPosition3D;
         private Vector3 anchoredPosition3D => rectTransform.anchoredPosition3D;
 
         /// <summary>
         /// Normalized position of the upper right corner in the parent UIRect.
         /// </summary>
-        private Vector2 anchorMax => GetComponent<RectTransform>().anchorMax;
         private Vector2 anchorMax => rectTransform.anchorMax;
 
         /// <summary>
         /// NNormalized position of the lower left corner in the parent UIRect.
         /// </summary>
-        private Vector2 anchorMin => GetComponent<RectTransform>().anchorMin;
         private Vector2 anchorMin => rectTransform.anchorMin;
 
         /// <summary>
         /// Distance between the upper right corner of this rectangle and the upper right anchor.
         /// </summary>
-        private Vector2 offsetMax => GetComponent<RectTransform>().offsetMax;
         private Vector2 offsetMax => rectTransform.offsetMax;
 
         /// <summary>
         /// Distance between the lower left corner of this rectangle and the lower left anchor.
         /// </summary>
-        private Vector2 offsetMin => GetComponent<RectTransform>().offsetMin;
         private Vector2 offsetMin => rectTransform.offsetMin;
 
         /// <summary>
         /// Pivot point.
         /// </summary>
-        private Vector2 pivot => GetComponent<RectTransform>().pivot;
         private Vector2 pivot => rectTransform.pivot;
 
         /// <summary>
         /// Relative size of the rectangle relative to the distance between upper right and lower left anchors.
         /// </summary>
-        private Vector2 sizeDelta => GetComponent<RectTransform>().sizeDelta;
         private Vector2 sizeDelta => rectTransform.sizeDelta;
 
         private bool rectMask => GetComponent<RectMask2D>() != null;
 
         protected internal RectTransform rectTransform;
+
+        protected internal bool useLayoutGrouping;
+
+        /// <summary>
+        /// If true, this rect is defined by a layout group.
+        /// </summary>
+        public bool UseLayoutGrouping => useLayoutGrouping;
+
 
         ///<see cref="anchoredPosition"/>
         public UMI3DAsyncProperty<Vector2> AnchoredPosition { get { Register(); return _anchoredPosition; } protected set => _anchoredPosition = value; }
@@ -135,6 +135,8 @@ namespace umi3d.edk
             Pivot = new UMI3DAsyncProperty<Vector2>(objectId, UMI3DPropertyKeys.Pivot, pivot, ToUMI3DSerializable.ToSerializableVector2, equality.Vector2Equality);
             SizeDelta = new UMI3DAsyncProperty<Vector2>(objectId, UMI3DPropertyKeys.SizeDelta, sizeDelta, ToUMI3DSerializable.ToSerializableVector2, equality.Vector2Equality);
             RectMask = new UMI3DAsyncProperty<bool>(objectId, UMI3DPropertyKeys.RectMask, rectMask);
+
+            useLayoutGrouping = TryGetComponent<LayoutGroup>(out _) || TryGetComponent<LayoutElement>(out _);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
UMI3D was not able to handle UIRect that were defined by a layout group. Now it is possible, by adding a UIDynamicLayoutUpdater on top of the hierarchy to handle.