### PR TITLE
Fix unable to set overrideProperty if canvas is disabled

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Loaders/Helpers.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Loaders/Helpers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6af465e04fee0494aae62fc0562d5c9f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Loaders/Helpers/ActivationEventListener.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Loaders/Helpers/ActivationEventListener.cs
@@ -1,0 +1,43 @@
+﻿/*
+Copyright 2019 - 2024 Inetum
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+using UnityEngine;
+
+namespace umi3d.cdk
+{
+    /// <summary>
+    /// To use only if there is no obvious way to listen to event otherwise.
+    /// </summary>
+    public class ActivationEventListener : MonoBehaviour
+    {
+        /// <summary>
+        /// Raised when the owning gameobject is enabled.
+        /// </summary>
+        public event System.Action OnEnabled;
+
+        /// <summary>
+        /// Raised when the owning gameobject is disabled.
+        /// </summary>
+        public event System.Action OnDisabled;
+
+        private void OnEnable()
+        {
+            OnEnabled?.Invoke();
+        }
+
+        private void OnDisable()
+        {
+            OnDisabled?.Invoke();
+        }
+    }
+}

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Loaders/Helpers/ActivationEventListener.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Loaders/Helpers/ActivationEventListener.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a4082a61b6f38e54ab1984f0f4a50308
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Reason : overrideSorting Unity property cannot be modified if object is disabled, need to update at each activation. Added a loader helper script for such reason