### PR TITLE
Improvement of tracking frame relay performances

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/Networking/UMI3DTrackingRelay.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/Networking/UMI3DTrackingRelay.cs
@@ -25,27 +25,84 @@ namespace umi3d.edk.collaboration.tracking
 {
     public class UMI3DTrackingRelay : UMI3DToUserRelay<List<UserTrackingFrameDto>>
     {
+        private const DebugScope debugScope = DebugScope.EDK | DebugScope.UserCapture | DebugScope.Collaboration | DebugScope.User;
+
+        /// <summary>
+        /// Contains all user tracking frames serialized for an update.
+        /// </summary>
+        protected Dictionary<NetworkingPlayer, byte[]> tempRawFramesPerPlayers;
+
+        /// <summary>
+        /// Temp list to contain all bytes to snd to a user.
+        /// </summary>
+        private List<byte> tempMessage = new();
 
         public UMI3DTrackingRelay(IForgeServer server) : base(server)
         {
             dataChannel = DataChannelTypes.Tracking;
+            tempRawFramesPerPlayers = new();
+        }
+
+        protected override void Update()
+        {
+            try
+            {
+                if (!UMI3DEnvironment.Instance.useDto)
+                {
+                    lock (framesPerSourceLock)
+                    {
+                        // Serialize all tracking frames once for all players.
+                        foreach ((NetworkingPlayer player, List<UserTrackingFrameDto> frames) in framesPerSource)
+                        {
+                            if (frames.Count == 1)
+                                tempRawFramesPerPlayers[player] = UMI3DSerializer.Write(frames[0]).ToBytes();
+                            else
+                            {
+                                UnityEngine.Debug.LogError("Tracking frame list should only contains one entry");
+                                tempRawFramesPerPlayers[player] = new byte[0];
+                            }
+                        }
+                    }
+                }
+
+                base.Update();
+            }
+            catch (System.Exception ex)
+            {
+                UMI3DLogger.LogError("Error while sending tracking frame", debugScope);
+                UMI3DLogger.LogException(ex, debugScope);
+            }
         }
 
         /// <inheritdoc/>
-        protected override byte[] GetMessage(List<List<UserTrackingFrameDto>> frames)
+        protected override byte[] GetMessage(List<NetworkingPlayer> fromPlayers)
         {
-            var _frames = frames.SelectMany(x => x).ToList();
             if (UMI3DEnvironment.Instance.useDto)
-                return (new UMI3DDtoListDto<UserTrackingFrameDto>() { values = _frames }).ToBson();
+            {
+                return (new UMI3DDtoListDto<UserTrackingFrameDto>() { values = fromPlayers.Select(player => framesPerSource[player][0]).ToList() }).ToBson();
+            }
             else
-                return UMI3DSerializer.WriteCollection(_frames).ToBytes();
+            {
+                tempMessage.Clear();
+                tempMessage.Add(UMI3DObjectKeys.CountArray);
+                tempMessage.AddRange(UMI3DSerializer.Write(fromPlayers.Count).ToBytes());
+                UnityEngine.Debug.Assert(tempMessage.Count == 5, tempMessage.Count);
 
+                foreach (NetworkingPlayer player in fromPlayers)
+                {
+                    if (tempRawFramesPerPlayers.ContainsKey(player))
+                        tempMessage.AddRange(tempRawFramesPerPlayers[player]);
+                    else
+                        UnityEngine.Debug.LogError($"Impossible to find tracking frame from {player.NetworkId}");
+                }
+
+                return tempMessage.ToArray();
+            }
         }
-
 
         public void SetFrame(NetworkingPlayer source, UserTrackingFrameDto frame)
         {
-            SetFrame(source, new List<UserTrackingFrameDto>() { frame });
+            SetFrame(source, new List<UserTrackingFrameDto> { frame });
         }
     }
 }


### PR DESCRIPTION
For 25 users in a simple room, sending tracking frames :
- execution time : 50ms -> 4ms
- GB Allocation : 15Mo -> 1Mo

The remaning GB Allocation is mostly related to serialization @TheoDesbonnets 
