### PR TITLE
Prevent error when trying to use a start/stop interpolation property with no value

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene synchronisation/StartInterpolationProperty.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene synchronisation/StartInterpolationProperty.cs
@@ -30,6 +30,45 @@ namespace umi3d.edk
         /// <inheritdoc/>
         public override Bytable ToBytable(UMI3DUser user)
         {
+            if (startValue == null)
+                UMI3DLogger.LogError($"{nameof(startValue)} property was not set for {nameof(StartInterpolationProperty)}", DebugScope.EDK | DebugScope.Core);
+
+            return UMI3DSerializer.Write(UMI3DOperationKeys.StartInterpolationProperty)
+                + UMI3DSerializer.Write(entityId)
+                + UMI3DSerializer.Write(property)
+                + UMI3DSerializer.Write(startValue);
+
+        }
+
+        /// <inheritdoc/>
+        public override AbstractOperationDto ToOperationDto(UMI3DUser user)
+        {
+            if (startValue == null)
+                UMI3DLogger.LogError($"{nameof(startValue)} property was not set for {nameof(StartInterpolationProperty)}", DebugScope.EDK | DebugScope.Core);
+
+            var startInterpolation = new StartInterpolationPropertyDto
+            {
+                property = property,
+                entityId = entityId,
+                startValue = startValue
+            };
+            return startInterpolation;
+        }
+    }
+
+    /// <summary>
+    /// An operation to start interpolatation on a property's entity.
+    /// </summary>
+    public class StartInterpolationProperty<PropertyType> : AbstractInterpolationProperty
+    {
+        /// <summary>
+        /// The value at which to start interpolation.
+        /// </summary>
+        public PropertyType startValue = default;
+
+        /// <inheritdoc/>
+        public override Bytable ToBytable(UMI3DUser user)
+        {
             return UMI3DSerializer.Write(UMI3DOperationKeys.StartInterpolationProperty)
                 + UMI3DSerializer.Write(entityId)
                 + UMI3DSerializer.Write(property)

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene synchronisation/StopInterpolationProperty.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene synchronisation/StopInterpolationProperty.cs
@@ -30,6 +30,44 @@ namespace umi3d.edk
         /// <inheritdoc/>
         public override Bytable ToBytable(UMI3DUser user)
         {
+            if (stopValue == null)
+                UMI3DLogger.LogError($"{nameof(stopValue)} property was not set for {nameof(StopInterpolationProperty)}", DebugScope.EDK | DebugScope.Core);
+
+            return UMI3DSerializer.Write(UMI3DOperationKeys.StopInterpolationProperty)
+                + UMI3DSerializer.Write(entityId)
+                + UMI3DSerializer.Write(property)
+                + UMI3DSerializer.Write(stopValue);
+        }
+
+        /// <inheritdoc/>
+        public override AbstractOperationDto ToOperationDto(UMI3DUser user)
+        {
+            if (stopValue == null)
+                UMI3DLogger.LogError($"{nameof(stopValue)} property was not set for {nameof(StopInterpolationProperty)}", DebugScope.EDK | DebugScope.Core);
+
+            var stopInterpolation = new StopInterpolationPropertyDto
+            {
+                property = property,
+                entityId = entityId,
+                stopValue = stopValue
+            };
+            return stopInterpolation;
+        }
+    }
+
+    /// <summary>
+    /// An opertion to stop interpolation on a property's entity
+    /// </summary>
+    public class StopInterpolationProperty<PropertyType> : AbstractInterpolationProperty
+    {
+        /// <summary>
+        /// The value with which to stop interpolation
+        /// </summary>
+        public PropertyType stopValue = default;
+
+        /// <inheritdoc/>
+        public override Bytable ToBytable(UMI3DUser user)
+        {
             return UMI3DSerializer.Write(UMI3DOperationKeys.StopInterpolationProperty)
                 + UMI3DSerializer.Write(entityId)
                 + UMI3DSerializer.Write(property)


### PR DESCRIPTION
- Raise an error with an explicit log if impossible
- Created two template classes that does the same but with a default value adapted to the type