### PR TITLE
Add animator lookAtProperties

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/UMI3DAnimatorAnimation.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/UMI3DAnimatorAnimation.cs
@@ -26,7 +26,7 @@ namespace umi3d.cdk
 {
     /// <summary>
     /// Animation played on an <see cref="Animator"/> component. The animation is typically inside a state
-    /// of the Mecanima Animator.
+    /// of the Mecanim Animator.
     /// </summary>
     public class UMI3DAnimatorAnimation : UMI3DAbstractAnimation
     {
@@ -74,6 +74,8 @@ namespace umi3d.cdk
         /// This animator could be shared by several <see cref="UMI3DAnimatorAnimation"/> as each animation
         /// corresponds to a state of the animator.
         protected Animator animator { get; private set; }
+
+        protected AnimatorIKRelay IKRelay { get; private set; }
 
         #endregion Fields
 
@@ -134,7 +136,11 @@ namespace umi3d.cdk
 
                         animator = (n as UMI3DNodeInstance)?.GameObject.GetComponentInChildren<Animator>();
                         if (animator != null)
+                        {
                             animator.Rebind();
+                            IKRelay = this.animator.gameObject.AddComponent<AnimatorIKRelay>();
+                            ApplyLookAtProperties();
+                        }
                     });
                 }
             );
@@ -294,6 +300,16 @@ namespace umi3d.cdk
                     dto.normalizedTime = (float)value.property.value;
                     break;
 
+                case UMI3DPropertyKeys.AnimationAnimatorLookAtPosition:
+                    dto.lookAtPosition = (Vector3Dto)value.property.value;
+                    ApplyLookAtProperties();
+                    break;
+
+                case UMI3DPropertyKeys.AnimationAnimatorLookAtWeight:
+                    dto.lookAtWeight = (float)value.property.value;
+                    ApplyLookAtProperties();
+                    break;
+
                 case UMI3DPropertyKeys.AnimationAnimatorParameters:
                     switch (value.property)
                     {
@@ -324,7 +340,6 @@ namespace umi3d.cdk
             return true;
         }
 
-
         public override async Task<bool> SetUMI3DProperty(SetUMI3DPropertyContainerData value)
         {
             if (await base.SetUMI3DProperty(value)) return true;
@@ -341,6 +356,16 @@ namespace umi3d.cdk
 
                 case UMI3DPropertyKeys.AnimationAnimatorNormalizedTime:
                     dto.normalizedTime = UMI3DSerializer.Read<float>(value.container);
+                    break;
+
+                case UMI3DPropertyKeys.AnimationAnimatorLookAtPosition:
+                    dto.lookAtPosition = UMI3DSerializer.Read<Vector3Dto>(value.container);
+                    ApplyLookAtProperties();
+                    break;
+
+                case UMI3DPropertyKeys.AnimationAnimatorLookAtWeight:
+                    dto.lookAtWeight = UMI3DSerializer.Read<float>(value.container);
+                    ApplyLookAtProperties();
                     break;
 
                 case UMI3DPropertyKeys.AnimationAnimatorParameters:
@@ -430,6 +455,45 @@ namespace umi3d.cdk
                 if (animator != null && dto.playing)
                     Start();
             });
+        }
+
+        /// <summary>
+        /// If true, the animator is listening to IK callback for lookAt properties.
+        /// </summary>
+        private bool listenToIKCallbackForLookAt = false;
+
+        /// <summary>
+        /// Apply look at properties to the animator.
+        /// </summary>
+        private void ApplyLookAtProperties()
+        {
+            if (animator == null)
+                return;
+
+            if (dto.lookAtWeight < 0)
+                dto.lookAtWeight = 0;
+
+            if (dto.lookAtWeight > 0 && !listenToIKCallbackForLookAt)
+            {
+                IKRelay.IkCallback += ApplyLookAtPropertiesOnIKCallback;
+                listenToIKCallbackForLookAt = true;
+            }
+            else if (dto.lookAtWeight == 0 && listenToIKCallbackForLookAt)
+            {
+                IKRelay.IkCallback -= ApplyLookAtPropertiesOnIKCallback;
+                listenToIKCallbackForLookAt = false;
+            }
+        }
+
+        private void ApplyLookAtPropertiesOnIKCallback(int layer)
+        {
+            if (animator == null) return; // destroyed in meanwhile
+
+            if (dto.lookAtWeight == 0) return;
+
+            // those methods can only be called in IK call in Unity lifecycle.
+            animator.SetLookAtPosition(dto.lookAtPosition.Struct());
+            animator.SetLookAtWeight(dto.lookAtWeight);
         }
 
         async void debugClip()

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/Utils.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3795e12e6b96498428a41437e6972738
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/Utils/AnimatorIKRelay.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/Utils/AnimatorIKRelay.cs
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,14 +14,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-namespace umi3d.cdk.userCapture.tracking.ik
+using System;
+using UnityEngine;
+
+namespace umi3d.cdk
 {
     /// <summary>
     /// Catches OnAnimatorIk event and dispatch it. Has to be on a gameobject with an animator component.
     /// </summary>
-    public class TrackedAnimator : AnimatorIKRelay
+    public class AnimatorIKRelay : MonoBehaviour
     {
-        // the content of this class has been migrated to its parent
-        // to include it in the core module without breaking existing prefabs.
+        /// <summary>
+        /// Triggered just before the related animator updates its own IK system.
+        /// </summary>
+        public event Action<int> IkCallback;
+
+        // mandatory for OnAnimatorIk event
+        public Animator Animator => animator;
+
+        private Animator animator;
+
+        private void Start()
+        {
+            animator = GetComponent<Animator>();
+        }
+
+        private void OnAnimatorIK(int layerIndex)
+        {
+            IkCallback?.Invoke(layerIndex);
+        }
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/Utils/AnimatorIKRelay.cs.meta
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Core/Runtime/Animation/Utils/AnimatorIKRelay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d602412d5e7d7c4c9c4919948994a14
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Dto/UMI3DContent/UMI3DAnimatorAnimationDto.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Dto/UMI3DContent/UMI3DAnimatorAnimationDto.cs
@@ -44,5 +44,15 @@ namespace umi3d.common
         /// Animator parameters.
         /// </summary>
         public Dictionary<string, object> parameters { get; set; } = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Look at position for the object.
+        /// </summary>
+        public Vector3Dto lookAtPosition { get; set; }
+
+        /// <summary>
+        /// Look at weight for the object.
+        /// </summary>
+        public float lookAtWeight { get; set; }
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Keys/UMI3DPropertyKeys.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Keys/UMI3DPropertyKeys.cs
@@ -272,6 +272,8 @@ namespace umi3d.common
         public const uint AnimationStateName = 13402;
         public const uint AnimationAnimatorParameters = 13403;
         public const uint AnimationAnimatorNormalizedTime = 13404;
+        public const uint AnimationAnimatorLookAtPosition = 13405;
+        public const uint AnimationAnimatorLookAtWeight = 13406;
 
         #endregion
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/Animation/UMI3DAnimatorAnimation.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/Scene Design/Animation/UMI3DAnimatorAnimation.cs
@@ -38,12 +38,27 @@ namespace umi3d.edk
         [SerializeField, EditorReadOnly, Tooltip("Current state's name in the animator controller. \n" +
                                                  "An empty state name corresponds to a self-caring animator.")]
         private string stateName = string.Empty;
-        
+
         /// <summary>
         /// Animation normalized time at start. 
         /// </summary>
         [SerializeField, EditorReadOnly, Tooltip("Animation normalized time at start.")]
         private float normalizedTime = 0f;
+
+        /// <summary>
+        /// Look at position for the animator's IK.
+        /// Make sure the animator has IK pass enabled on first layer.
+        /// </summary>
+        [SerializeField, Tooltip("Look at position for the animator's IK.\n Make sure the animator has IK pass enabled on first layer.")]
+        private Vector3 lookAtPosition = Vector3.zero;
+
+        /// <summary>
+        /// Look at weight for the animator's IK.
+        /// Make sure the animator has IK pass enabled on first layer.
+        /// </summary>
+        /// A 0 value disable IK look at.
+        [SerializeField, Tooltip("Look at weight for the animator's IK.\n Make sure the animator has IK pass enabled on first layer.")]
+        private float lookAtWeight = 0f;
 
         /// <summary>
         /// See <see cref="node"/>.
@@ -57,6 +72,14 @@ namespace umi3d.edk
         /// See <see cref="normalizedTime"/>.
         /// </summary>
         private UMI3DAsyncProperty<float> _objectNormalizedTime;
+        /// <summary>
+        /// See <see cref="lookAtPosition"/>.
+        /// </summary>
+        private UMI3DAsyncProperty<Vector3> _objectLookAtPosition;
+        /// <summary>
+        /// See <see cref="lookAtWeight"/>.
+        /// </summary>
+        private UMI3DAsyncProperty<float> _objectLookAtWeight;
         /// <summary>
         /// <see cref="objectParameters"/>.
         /// </summary>
@@ -74,6 +97,14 @@ namespace umi3d.edk
         /// See <see cref="normalizedTime"/>.
         /// </summary>
         public UMI3DAsyncProperty<float> objectNormalizedTime { get { Register(); return _objectNormalizedTime; } protected set => _objectNormalizedTime = value; }
+        /// <summary>
+        /// See <see cref="lookAtPosition"/>.
+        /// </summary>
+        public UMI3DAsyncProperty<Vector3> objectLookAtPosition { get { Register(); return _objectLookAtPosition; } protected set => _objectLookAtPosition = value; }
+        /// <summary>
+        /// See <see cref="lookAtWeight"/>.
+        /// </summary>
+        public UMI3DAsyncProperty<float> objectLookAtWeight { get { Register(); return _objectLookAtWeight; } protected set => _objectLookAtWeight = value; }
         /// <summary>
         /// Property to change <see cref="Animator"/> parameters. Allowed values are float, integer, bool (value true for trigger parameter).
         /// </summary>
@@ -94,6 +125,8 @@ namespace umi3d.edk
             objectNode = new UMI3DAsyncProperty<UMI3DNode>(id, UMI3DPropertyKeys.AnimationNodeId, node, null, (o, u) => o.Equals(u));
             objectStateName = new UMI3DAsyncProperty<string>(id, UMI3DPropertyKeys.AnimationStateName, stateName, null, (o, u) => o.Equals(u));
             objectNormalizedTime = new UMI3DAsyncProperty<float>(id, UMI3DPropertyKeys.AnimationAnimatorNormalizedTime, normalizedTime, null, (o, u) => o.Equals(u));
+            objectLookAtPosition = new UMI3DAsyncProperty<Vector3>(id, UMI3DPropertyKeys.AnimationAnimatorLookAtPosition, lookAtPosition, null, (o, u) => o.Equals(u));
+            objectLookAtWeight = new UMI3DAsyncProperty<float>(id, UMI3DPropertyKeys.AnimationAnimatorLookAtWeight, lookAtWeight, null, (o, u) => o.Equals(u));
             objectParameters = new UMI3DAsyncDictionnaryProperty<string, object>(id, UMI3DPropertyKeys.AnimationAnimatorParameters,
                 new Dictionary<string, object>(), null, (o, u) => UMI3DAnimatorParameter.Create(o), null, d =>
                 {
@@ -103,6 +136,8 @@ namespace umi3d.edk
             objectNode.OnValueChanged += (d) => node = d;
             objectStateName.OnValueChanged += (d) => stateName = d;
             objectNormalizedTime.OnValueChanged += (d) => normalizedTime = d;
+            objectLookAtPosition.OnValueChanged += (d) => lookAtPosition = d;
+            objectLookAtWeight.OnValueChanged += (d) => lookAtWeight = d;
         }
 
         /// <inheritdoc/>
@@ -113,6 +148,8 @@ namespace umi3d.edk
             Adto.nodeId = objectNode.GetValue(user).Id();
             Adto.stateName = objectStateName.GetValue(user);
             Adto.normalizedTime = objectNormalizedTime.GetValue(user);
+            Adto.lookAtPosition = objectLookAtPosition.GetValue(user).Dto();
+            Adto.lookAtWeight = objectLookAtWeight.GetValue(user);
             Adto.parameters = objectParameters.GetValue(user);
         }
 
@@ -123,6 +160,8 @@ namespace umi3d.edk
                 + UMI3DSerializer.Write(objectNode.GetValue(user).Id())
                 + UMI3DSerializer.Write(objectStateName.GetValue(user))
                 + UMI3DSerializer.Write(objectNormalizedTime.GetValue(user))
+                + UMI3DSerializer.Write(objectLookAtPosition.GetValue(user).Dto())
+                + UMI3DSerializer.Write(objectLookAtWeight.GetValue(user))
                 + UMI3DSerializer.Write(objectParameters.GetValue(user));
         }
     }


### PR DESCRIPTION
Add two async properties to the UMI3DAnimatorAnimation : LookAtPosition and LookAtWeight.
Those are used to use the corresponding IK methods from Unity for animator animations not on user's avatars but on normal objects that possess an animator and IKs. For example a human npc.

⚠️ The TrackedAnimator logic, listening to IK callbacks from CDK.UserCapture was moved into the AnimatorIKRelay of the CDK.Core, and TrackedAnimator was made of child of AnimatorIKRelay not to break any existing prefab using this Monobehaviour.