### PR TITLE
Move umi3d server state access to umi3dServer

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/IUMI3DCollaborationServer.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/IUMI3DCollaborationServer.cs
@@ -29,21 +29,6 @@ namespace umi3d.edk.collaboration
     {
         bool IsResourceServerSetup { get; }
 
-        /// <summary>
-        /// Is the server active?
-        /// </summary>
-        bool isRunning { get; }
-      
-        /// <summary>
-        /// Event called when the UMI3D server is launched.
-        /// </summary>
-        event Action OnServerStarted;
-
-        /// <summary>
-        /// Event called when the UMI3D server has been stopped.
-        /// </summary>
-        event Action OnServerStopped;
-
         void ClearIP();
 
         void Init();

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/UMI3DCollaborationServer.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/UMI3DCollaborationServer.cs
@@ -285,7 +285,7 @@ namespace umi3d.edk.collaboration
 
             WorldController.SetupAfterServerStart();
             OnServerStart.Invoke();
-            OnServerStarted?.Invoke();
+            NotifyServerStarted();
         }
 
         private void ShouldAcceptPlayer(string identity, NetworkingPlayer player, Action<bool> action)
@@ -437,7 +437,7 @@ namespace umi3d.edk.collaboration
             {
                 isRunning = false;
                 OnServerStop.Invoke();
-                OnServerStopped?.Invoke();
+                NotifyServerStopped();
             }
             if (mumbleManager != null)
                 mumbleManager.Delete();
@@ -457,7 +457,7 @@ namespace umi3d.edk.collaboration
             {
                 isRunning = false;
                 OnServerStop.Invoke();
-                OnServerStopped?.Invoke();
+                NotifyServerStopped();
             }
             if (mumbleManager != null)
                 mumbleManager.Delete();
@@ -757,16 +757,6 @@ namespace umi3d.edk.collaboration
         public UnityEvent OnServerStart = new UnityEvent();
         [Obsolete("Use OnServerStopped instead.")]
         public UnityEvent OnServerStop = new UnityEvent();
-
-        /// <summary>
-        /// Event called when the UMI3D server is launched.
-        /// </summary>
-        public event System.Action OnServerStarted;
-
-        /// <summary>
-        /// Event called when the UMI3D server has been stopped.
-        /// </summary>
-        public event System.Action OnServerStopped;
         #endregion
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/IUMI3DServer.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/IUMI3DServer.cs
@@ -33,6 +33,21 @@ namespace umi3d.edk
         UMI3DUserEvent OnUserRegistered { get; }
         UMI3DUserEvent OnUserUnregistered { get; }
 
+        /// <summary>
+        /// Is the server active?
+        /// </summary>
+        bool isRunning { get; }
+
+        /// <summary>
+        /// Event called when the UMI3D server is launched.
+        /// </summary>
+        event System.Action OnServerStarted;
+
+        /// <summary>
+        /// Event called when the UMI3D server has been stopped.
+        /// </summary>
+        event System.Action OnServerStopped;
+
         void NotifyUserRefreshed(UMI3DUser user);
         void NotifyUserChanged(UMI3DUser user);
         void NotifyUserStatusChanged(UMI3DUser user, StatusType status);

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/UMI3DServer.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Core/Runtime/UMI3DServer.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Linq;
 using umi3d.common;
 using UnityEngine;
+using System;
 
 namespace umi3d.edk
 {
@@ -35,6 +36,11 @@ namespace umi3d.edk
         /// Default to "Localhost.
         [SerializeField, Tooltip("IP of the UMI3D server.")]
         protected string ip = "localhost";
+
+        /// <summary>
+        /// Is the server active?
+        /// </summary>
+        public bool isRunning { get; protected set; } = false;
 
         /// <summary>
         /// Initialize the server.
@@ -59,6 +65,16 @@ namespace umi3d.edk
         private string privateDataFullPath;
         private string dataFullPath;
 
+        /// <summary>
+        /// Event called when the UMI3D server is launched.
+        /// </summary>
+        public event System.Action OnServerStarted;
+
+        /// <summary>
+        /// Event called when the UMI3D server has been stopped.
+        /// </summary>
+        public event System.Action OnServerStopped;
+
         public static string publicRepository => Instance?.publicDataFullPath;
         public static string privateRepository => Instance?.privateDataFullPath;
         public static string dataRepository => Instance?.dataFullPath;
@@ -79,6 +95,16 @@ namespace umi3d.edk
         {
             string fullPath = System.IO.Path.GetFullPath(path);
             return fullPath.StartsWith(publicRepository);
+        }
+
+        protected void NotifyServerStarted()
+        {
+            OnServerStarted?.Invoke();
+        }
+
+        protected void NotifyServerStopped()
+        {
+            OnServerStopped?.Invoke();
         }
 
         #endregion


### PR DESCRIPTION
UMI3DServer should have a state, even if the default implementation of UMI3DServer is currently anemic and cannot work without Collaboration