### PR TITLE
Add estimated duration property to emotes

### DIFF
--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Emotes/Loaders/UMI3DEmoteLoader.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Emotes/Loaders/UMI3DEmoteLoader.cs
@@ -118,6 +118,11 @@ namespace umi3d.cdk.collaboration.emotes
                     emoteManagementService.UpdateEmote(emote);
                     break;
 
+                case UMI3DPropertyKeys.EstimatedDurationEmote:
+                    emote.estimatedDuration = (float)value.property.value;
+                    emoteManagementService.UpdateEmote(emote);
+                    break;
+
                 default:
                     return await Task.FromResult(false);
             }
@@ -145,6 +150,11 @@ namespace umi3d.cdk.collaboration.emotes
                     emoteManagementService.UpdateEmote(emote);
                     break;
 
+                case UMI3DPropertyKeys.EstimatedDurationEmote:
+                    emote.estimatedDuration = UMI3DSerializer.Read<float>(value.container);
+                    emoteManagementService.UpdateEmote(emote);
+                    break;
+
                 default:
                     return await Task.FromResult(false);
             }
@@ -161,6 +171,7 @@ namespace umi3d.cdk.collaboration.emotes
             switch (data.propertyKey)
             {
                 case UMI3DPropertyKeys.ActiveEmote:
+                case UMI3DPropertyKeys.EstimatedDurationEmote:
                 case UMI3DPropertyKeys.AnimationEmote:
                     {
                         UMI3DEmoteDto emoteDto = UMI3DSerializer.Read<UMI3DEmoteDto>(data.container);
@@ -171,6 +182,7 @@ namespace umi3d.cdk.collaboration.emotes
 
                         emote.available = emoteDto.available;
                         emote.AnimationId = emoteDto.animationId;
+                        emote.estimatedDuration = emoteDto.estimatedDuration;
                         emoteManagementService.UpdateEmote(emote);
                         break;
                     }

--- a/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Emotes/Objects/Emote.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/ClientDevelopmentKit/Collaboration/Runtime/Emotes/Objects/Emote.cs
@@ -33,6 +33,7 @@ namespace umi3d.cdk.collaboration.emotes
             this.available = dto.available;
             this.AnimationId = dto.animationId;
             this.EnvironmentId = environmentId;
+            this.estimatedDuration = dto.estimatedDuration > 0 ? dto.estimatedDuration : null;
         }
 
         /// <summary>
@@ -63,5 +64,11 @@ namespace umi3d.cdk.collaboration.emotes
         /// Should the emote be available or not
         /// </summary>
         public bool available { get; internal set; }
+
+        /// <summary>
+        /// Estimated duration of the emote in seconds.
+        /// </summary>
+        /// A null value indicates no available estimation.
+        public float? estimatedDuration { get; internal set; }
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/Collaboration/Runtime/Dto/Emotes/UMI3DEmoteDto.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/Collaboration/Runtime/Dto/Emotes/UMI3DEmoteDto.cs
@@ -40,5 +40,10 @@ namespace umi3d.common.collaboration.dto.emotes
         /// Emote animation in the bundled animator
         /// </summary>
         public ulong animationId { get; set; }
+
+        /// <summary>
+        /// Estimated duration of the emote animation
+        /// </summary>
+        public float estimatedDuration { get; set; }
     }
 }

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/Collaboration/Runtime/Serializers/Emotes/UMI3DEmoteSerializerModule.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/Collaboration/Runtime/Serializers/Emotes/UMI3DEmoteSerializerModule.cs
@@ -34,6 +34,7 @@ namespace umi3d.common.collaboration.emotes
             readable &= UMI3DSerializer.TryRead(container, out ulong animationId);
             readable &= UMI3DSerializer.TryRead(container, out bool available);
             readable &= UMI3DSerializer.TryRead(container, out ResourceDto iconResource);
+            readable &= UMI3DSerializer.TryRead(container, out float estimatedDuration);
 
             if (readable)
             {
@@ -43,7 +44,8 @@ namespace umi3d.common.collaboration.emotes
                     label = label,
                     animationId = animationId,
                     available = available,
-                    iconResource = iconResource
+                    iconResource = iconResource,
+                    estimatedDuration = estimatedDuration,
                 };
                 result = e;
             }
@@ -58,7 +60,8 @@ namespace umi3d.common.collaboration.emotes
                 + UMI3DSerializer.Write(dto.label)
                 + UMI3DSerializer.Write(dto.animationId)
                 + UMI3DSerializer.Write(dto.available)
-                + UMI3DSerializer.Write(dto.iconResource);
+                + UMI3DSerializer.Write(dto.iconResource)
+                + UMI3DSerializer.Write(dto.estimatedDuration);
 
             return true;
         }

--- a/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Keys/UMI3DPropertyKeys.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/Common/Core/Runtime/Keys/UMI3DPropertyKeys.cs
@@ -217,6 +217,7 @@ namespace umi3d.common
         public const uint ChangeEmoteConfig = 11005; // deprecated
         public const uint ActiveEmote = 11006;
         public const uint AnimationEmote = 11007;
+        public const uint EstimatedDurationEmote = 11500; // added afterwards. Beware.
 
         public const uint Poses = 11008;
         public const uint ValidationEnvironmentPoseCondition = 11009;
@@ -242,6 +243,9 @@ namespace umi3d.common
         public const uint TrackingConstraintConstrainingBone = 11115;
 
         public const uint UserActions = 11200;
+        
+        // Values between 11500-12000 are reserved for adding more properties to usercapture
+        // See property DurationEmote for example
 
         #endregion
 

--- a/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/Emotes/Objects/UMI3DEmote.cs
+++ b/UMI3D-SDK/Assets/UMI3D SDK/EnvironmentDevelopmentKit/Collaboration/Runtime/Emotes/Objects/UMI3DEmote.cs
@@ -52,6 +52,28 @@ namespace umi3d.edk.collaboration.emotes
         protected UMI3DAsyncProperty<ulong> _animationId;
 
         /// <summary>
+        /// Estimated duration of the emote in seconds.
+        /// </summary>
+        public virtual UMI3DAsyncProperty<float> EstimatedDuration
+        {
+            get
+            {
+                _estimatedDuration ??= new UMI3DAsyncProperty<float>(Id(), UMI3DPropertyKeys.EstimatedDurationEmote, estimatedDuration);
+                return _estimatedDuration;
+            }
+            private set => _estimatedDuration = value;
+        }
+
+        protected UMI3DAsyncProperty<float> _estimatedDuration;
+
+        /// <summary>
+        /// Estimated duration of the emote in seconds.
+        /// </summary>
+        /// A null value indicates no available estimation.
+        [Tooltip("Estimated duration of the emote in seconds.\nIf unknown, the value can be set to 0.")]
+        public float estimatedDuration = 0;
+
+        /// <summary>
         /// If the user can see and play the emote.
         /// </summary>
         public virtual UMI3DAsyncProperty<bool> Available
@@ -94,6 +116,7 @@ namespace umi3d.edk.collaboration.emotes
                 id = this.Id(),
                 label = this.label,
                 animationId = this.AnimationId.GetValue(user), // create a DTO
+                estimatedDuration = this.EstimatedDuration.GetValue(user),
                 available = this.availableAtStart,
                 iconResource = this.iconResource.ToDto(),
             };


### PR DESCRIPTION
Add an EstimatedDuration property to emotes. This value can be used for browsers to convey feedback on an ongoing emote.